### PR TITLE
hoyt: fused iterate + in-struct gap pricing (#82) — anchor 88.6s -> 15.9s, 14.2x paired sweep

### DIFF
--- a/hoyt/CONTRACTS.md
+++ b/hoyt/CONTRACTS.md
@@ -71,6 +71,8 @@ team-pair deviation out of scope.
   perf goals) so the CFR lane never blocks on the kernel lane.
 - Neither lane edits existing walt modules, this file, or the other lane's
   files. Python via `/Users/jason/code/mk5-main/.venv/bin/python -u` from
-  the worktree root. numba install allowed via
-  `uv pip install --python /Users/jason/code/mk5-main/.venv/bin/python numba`.
+  the worktree root. numba is a RUNTIME dependency since the fused iterate
+  engine (#82, `hoyt/iterkernel.py` — cfr_solve's default engine); install
+  via `uv pip install --python /Users/jason/code/mk5-main/.venv/bin/python
+  numba` (engine="wave"/"loop" stay numba-free).
   Benches ≤10 min wall. Temp files in scratch/.

--- a/hoyt/CONTRACTS.md
+++ b/hoyt/CONTRACTS.md
@@ -72,7 +72,9 @@ team-pair deviation out of scope.
 - Neither lane edits existing walt modules, this file, or the other lane's
   files. Python via `/Users/jason/code/mk5-main/.venv/bin/python -u` from
   the worktree root. numba is a RUNTIME dependency since the fused iterate
-  engine (#82, `hoyt/iterkernel.py` — cfr_solve's default engine); install
-  via `uv pip install --python /Users/jason/code/mk5-main/.venv/bin/python
-  numba` (engine="wave"/"loop" stay numba-free).
+  engine (#82, `hoyt/iterkernel.py` — cfr_solve's default engine; the
+  fused lane's structural build also uses `hoyt/buildkernel.py`, perf-log
+  18n); install via `uv pip install --python
+  /Users/jason/code/mk5-main/.venv/bin/python numba`
+  (engine="wave"/"loop" stay numba-free).
   Benches ≤10 min wall. Temp files in scratch/.

--- a/hoyt/br.py
+++ b/hoyt/br.py
@@ -201,7 +201,7 @@ def br_solve(subgame: Subgame, profile, payoff43, hero=None, *,
     for hv in np.unique(hands):
         m = hands == hv
         res = run_engine(sub, provider, hero=hero,
-                         worlds=sub.worlds_i64[m], weights=sub.weights[m],
+                         worlds=sub.worlds_i32[m], weights=sub.weights[m],
                          heromask0=int(hv), need_path_ids=needs_ids,
                          slot_budget=slot_budget)
         vals, choice = backward(res["waves"], _leaf_vals(res, payoff43),

--- a/hoyt/buildkernel.py
+++ b/hoyt/buildkernel.py
@@ -1,0 +1,38 @@
+"""hoyt/buildkernel.py — numba kernels for the CFR structural build.
+
+The engine="fused" lane's expand_full_width provider (perf-log 18n): the
+numpy mirror materializes a (slots, 28) bool matrix per wave and scans it
+with np.nonzero to emit (slot, move) pairs — ~1 s of nonzero plus the
+matrix allocation per anchor build. This kernel emits the pairs straight
+off the legal-move bitmasks in the SAME ascending (slot, move) order
+(np.nonzero's row-major order), so the walk's output is identical by
+construction — integer structure, no floats, no tolerance.
+
+The wave/loop lanes stay numba-free (CONTRACTS.md): the numpy provider
+path remains the pinned mirror, selected by _FullWidthProvider(kernels=
+False), and the standing fused-vs-wave bitwise parity gates therefore
+cover this kernel too.
+"""
+from __future__ import annotations
+
+from numba import njit
+
+__all__ = ["fw_fill"]
+
+
+@njit(cache=True, boundscheck=False)
+def fw_fill(lm, off, si, mv):
+    """Scatter each slot's legal-move bitmask into flat (si, mv) arrays,
+    ascending (slot, move); off[i] is the running popcount offset of slot
+    i (caller computes it from np.bitwise_count + cumsum)."""
+    for i in range(lm.shape[0]):
+        m = lm[i]
+        k = off[i]
+        t = 0
+        while m:
+            if m & 1:
+                si[k] = i
+                mv[k] = t
+                k += 1
+            m >>= 1
+            t += 1

--- a/hoyt/cfr.py
+++ b/hoyt/cfr.py
@@ -456,9 +456,18 @@ def _build_wave(root, worlds, weights, pinned: dict, slot_budget,
                 ec["h1"].append(wj["ph1"][u_node[selE]])
                 ec["h2"].append(wj["ph2"][u_node[selE]])
                 ec["off"].append(off[selE])
-                ec["cnt"].append(nleg[selE])
-                bmE = ((lm[selE, None] >> _AR28) & 1).astype(bool)
-                ec["mv"].append(np.nonzero(bmE)[1].astype(np.int8))
+                cntE = nleg[selE]
+                ec["cnt"].append(cntE)
+                if kernels:
+                    from hoyt.buildkernel import fw_fill
+                    offE = np.concatenate(([0], np.cumsum(cntE)))
+                    siE = np.empty(offE[-1], dtype=np.int64)
+                    mvE = np.empty(offE[-1], dtype=np.int64)
+                    fw_fill(lm[selE], offE, siE, mvE)
+                    ec["mv"].append(mvE.astype(np.int8))
+                else:
+                    bmE = ((lm[selE, None] >> _AR28) & 1).astype(bool)
+                    ec["mv"].append(np.nonzero(bmE)[1].astype(np.int8))
             wj["ph1"] = wj["ph2"] = None
         iset_reached = None
         if pinned:

--- a/hoyt/cfr.py
+++ b/hoyt/cfr.py
@@ -71,9 +71,15 @@ cfr_solve touches the subgame ONLY through `.root/.worlds/.weights`, and
 touches the injected `impl` module ONLY through:
 
     impl.br_solve(subgame, profile, payoff43, hero=seat,
-                  want_strategy=False)                    # gap pricing
+                  want_strategy=False)     # gap pricing, engine="loop" only
     impl.StochasticProfile()                              # export format
     profile.set(seat, hand_mask, node, moves, probs)      # one call per iset
+
+The wave/fused engines price gaps IN-STRUCT (`_wave_br`: exact single-seat
+BR as a forward-reach + backward-argmax pass over the resident wave
+structure — no export, no re-walk; perf-log 18m) and export the profile
+once at the stop. impl.br_solve remains the standing pricing oracle via
+the loop engine and the P4 cross-gate (1e-9).
 
 where node = tuple of domino ids played since the root (the profile-domain
 convention in hoyt/reference.py; the kernel lane hashes it
@@ -577,6 +583,60 @@ def _wave_values(ws: _WaveStruct, sig, payleaf) -> np.ndarray:
     return v
 
 
+def _wave_br(ws: _WaveStruct, asig, u, payleaf, sign_u, rmu_store) -> float:
+    """Exact single-seat best response of seat u vs the profile `asig`,
+    computed IN-STRUCT (perf-log 18m, Fable consult L1): the resident wave
+    structure already contains everything exact BR needs, so gap pricing
+    stops re-walking the subgame through impl.br_solve per measurement
+    (which paid the stochastic-profile tree blowup, ~13 s/measurement on
+    the anchor, 65-71% of solve wall).
+
+    Forward: counterfactual reach r_mu (chance x all seats except u; u's
+    edges at prob 1). Backward: at u's info sets, score each strategy slot
+    by bincount of r_mu * child-value over the iset's worlds and pick the
+    per-iset argmax of the SIGNED score (u maximizes its team's
+    orientation); the chosen move's per-world child values propagate
+    unweighted. Elsewhere sigma-weighted expectation. Ties pick the lowest
+    move — value-identical by definition of a tie. Zero-reach isets choose
+    arbitrarily and contribute zero (the same exactness argument as pinned
+    support pruning). Cross-checked against impl.br_solve at 1e-9 (gate P4
+    in test_cfr_parity; the loop engine still prices through br_solve as
+    the standing oracle)."""
+    L = ws.L
+    r_mu = ws.w0
+    for j in range(L):
+        pr = asig[ws.GID[j]]
+        ue = ws.uedge[j][u]
+        rmu_store[j] = r_mu
+        pm = pr
+        if len(ue):
+            pm = pr.copy()
+            pm[ue] = 1.0
+        r_mu = r_mu[ws.PS[j]] * pm
+    v = payleaf
+    for j in range(L - 1, -1, -1):
+        pr = asig[ws.GID[j]]
+        ue = ws.uedge[j][u]
+        w = pr * v
+        if len(ue):
+            gid_l = ws.GID[j][ue] - ws.woff[j]
+            sc = np.bincount(gid_l, weights=rmu_store[j][ws.PS[j][ue]] * v[ue],
+                             minlength=ws.wlen[j])
+            si = ws.slot_iset[ws.woff[j]:ws.woff[j] + ws.wlen[j]]
+            imin = si[0]
+            ssc = sign_u * sc
+            gmax = np.full(int(si[-1]) - int(imin) + 1, -np.inf)
+            np.maximum.at(gmax, si - imin, ssc)
+            chosen = ssc == gmax[si - imin]
+            idxs = np.flatnonzero(chosen)
+            first = idxs[np.unique((si - imin)[idxs], return_index=True)[1]]
+            sel = np.zeros(ws.wlen[j], dtype=bool)
+            sel[first] = True
+            w[ue] = np.where(sel[gid_l], v[ue], 0.0)
+        v = np.bincount(ws.PS[j], weights=w, minlength=ws.S[j])
+    return float(ws.w0 @ v) / ws.total_w
+
+
 def _wave_pass(ws: _WaveStruct, sig, u, payleaf, cf, xI) -> None:
     """One update traversal for seat u: forward reaches, backward values,
     counterfactual accumulation into cf (flat slots) and own-reach into xI."""
@@ -929,8 +989,13 @@ def _solve_wave(subgame, payoff43, iters, target_gap, br_every, impl,
         tm["export"] += time.time() - t1
         return prof
 
+    rmu_br = [None] * ws.L
+
     def measure(asig):
-        prof = export(asig)
+        # in-struct pricing (perf-log 18m / Fable consult L1): no export,
+        # no impl.br_solve re-walk — the wave structure is already resident.
+        # Cross-gated vs impl.br_solve at 1e-9 (P4); loop engine keeps the
+        # br_solve path as the standing oracle.
         t1 = time.time()
         v0 = _wave_values(ws, asig, payleaf)
         vbar = float(ws.w0 @ v0) / ws.total_w
@@ -938,11 +1003,10 @@ def _solve_wave(subgame, payoff43, iters, target_gap, br_every, impl,
         t1 = time.time()
         gap = 0.0
         for u in live_seats:
-            bru = impl.br_solve(subgame, prof, payoff43, hero=u,
-                                want_strategy=False).value
+            bru = _wave_br(ws, asig, u, payleaf, signs[u], rmu_br)
             gap = max(gap, signs[u] * (bru - vbar))
         tm["br"] += time.time() - t1
-        return prof, vbar, gap
+        return vbar, gap
 
     trace: list = []
     result = None
@@ -979,16 +1043,17 @@ def _solve_wave(subgame, payoff43, iters, target_gap, br_every, impl,
         tm["iterate"] += time.time() - t1
         if it % br_every == 0 or it == iters or over():
             asig = averaged()
-            prof, vbar, gap = measure(asig)
+            vbar, gap = measure(asig)
             trace.append((it, gap))
-            result = (prof, vbar, gap)
+            result = (asig, vbar, gap)
             if target_gap is not None and gap <= target_gap:
                 break
             if over():                 # budget-driven stop, gap just priced
                 capped = True
                 break
 
-    prof, vbar, gap = result
+    asig_f, vbar, gap = result
+    prof = export(asig_f)              # once, at the stop — not per measure
     dbg = None
     if debug:
         asig = averaged()

--- a/hoyt/cfr.py
+++ b/hoyt/cfr.py
@@ -827,7 +827,8 @@ def cfr_solve(subgame, payoff43, iters: int = 200, target_gap: float | None = No
               seed: int = 0, br_every: int = 10, impl=None,
               pinned: dict | None = None, debug: bool = False,
               engine: str = "fused", slot_budget: int | None = None,
-              wall_budget_s: float | None = None) -> CFRResult:
+              wall_budget_s: float | None = None,
+              gap_exit: bool = False) -> CFRResult:
     """CFR+ over all four seats' info sets; gap priced by impl.br_solve.
 
     Args:
@@ -871,6 +872,18 @@ def cfr_solve(subgame, payoff43, iters: int = 200, target_gap: float | None = No
             of silently diverging (it is toy-sized only, where wall budgets
             are meaningless anyway). None (default) is behaviorally
             identical to the pre-knob solver.
+        gap_exit: intermediate gap measurements price seats in descending
+            last-known-gap order and stop at the first seat whose BR gain
+            exceeds target_gap (perf-log 18o). Exact by construction: the
+            continue/stop decision only needs "gap > target", convergence
+            is only declared after all live seats are priced, and any
+            measurement that can end the solve without convergence (iters
+            exhausted, wall budget) prices all seats — so the stop
+            iteration, final profile, value, and gap are IDENTICAL to
+            gap_exit=False; only intermediate trace entries change (they
+            record the certified-above-target partial max). Deterministic.
+            wave/fused only: partial intermediate traces can't be
+            parity-pinned against the loop mirror, so the loop raises.
     """
     del seed  # deterministic full-width solve; kept for contract stability
     if impl is None:
@@ -890,10 +903,14 @@ def cfr_solve(subgame, payoff43, iters: int = 200, target_gap: float | None = No
         raise ValueError("wall_budget_s requires engine='fused' or 'wave' "
                          "(the loop engine is the frozen parity mirror; "
                          "wall-driven stops cannot be parity-pinned)")
+    if gap_exit and engine == "loop":
+        raise ValueError("gap_exit requires engine='fused' or 'wave' "
+                         "(partial intermediate traces cannot be "
+                         "parity-pinned against the loop mirror)")
     if engine in ("fused", "wave"):
         return _solve_wave(subgame, payoff43, iters, target_gap, br_every,
                            impl, pinned, debug, slot_budget, wall_budget_s,
-                           fused=(engine == "fused"))
+                           fused=(engine == "fused"), gap_exit=gap_exit)
     return _solve_loop(subgame, payoff43, iters, target_gap, br_every,
                        impl, pinned, debug)
 
@@ -930,7 +947,7 @@ def _avg_sig(sig, avg, slot_iset, nlegal_slot, n_isets, unpinned_mask):
 
 def _solve_wave(subgame, payoff43, iters, target_gap, br_every, impl,
                 pinned, debug, slot_budget, wall_budget_s=None,
-                fused=False) -> CFRResult:
+                fused=False, gap_exit=False) -> CFRResult:
     tm = {"build": 0.0, "iterate": 0.0, "export": 0.0, "br": 0.0,
           "value": 0.0}
     t0 = time.time()
@@ -984,21 +1001,32 @@ def _solve_wave(subgame, payoff43, iters, target_gap, br_every, impl,
         return prof
 
     rmu_br = [None] * ws.L
+    last_gap = {u: np.inf for u in live_seats}   # unpriced ⇒ price first
 
-    def measure(asig):
+    def measure(asig, partial=False):
         # in-struct pricing (perf-log 18m / Fable consult L1): no export,
         # no impl.br_solve re-walk — the wave structure is already resident.
         # Cross-gated vs impl.br_solve at 1e-9 (P4); loop engine keeps the
         # br_solve path as the standing oracle.
+        # partial (gap_exit, perf-log 18o): an INTERMEDIATE measurement only
+        # decides continue-vs-stop, and gap > target ⇔ some seat's BR gain >
+        # target — so price seats (largest last-known gap first) and exit at
+        # the first crossing. Convergence is only ever declared after ALL
+        # live seats priced, so a stopping gap is always the exact full max;
+        # the exit cannot change the stop iteration or the final result.
         t1 = time.time()
         v0 = _wave_values(ws, asig, payleaf)
         vbar = float(ws.w0 @ v0) / ws.total_w
         tm["value"] += time.time() - t1
         t1 = time.time()
         gap = 0.0
-        for u in live_seats:
+        for u in sorted(live_seats, key=lambda s: (-last_gap[s], s)):
             bru = _wave_br(ws, asig, u, payleaf, signs[u], rmu_br)
-            gap = max(gap, signs[u] * (bru - vbar))
+            g = signs[u] * (bru - vbar)
+            last_gap[u] = g
+            gap = max(gap, g)
+            if partial and target_gap is not None and gap > target_gap:
+                break
         tm["br"] += time.time() - t1
         return vbar, gap
 
@@ -1035,16 +1063,24 @@ def _solve_wave(subgame, payoff43, iters, target_gap, br_every, impl,
                 _rm_plus_update(sig, reg, avg, cf, xI, upd[u], ws.slot_iset,
                                 ws.nlegal_slot, ws.n_isets, signs[u], it)
         tm["iterate"] += time.time() - t1
-        if it % br_every == 0 or it == iters or over():
+        budget_stop = over()
+        if it % br_every == 0 or it == iters or budget_stop:
             asig = averaged()
-            vbar, gap = measure(asig)
+            # a measurement that can end the solve WITHOUT convergence
+            # (iters exhausted / wall budget) must price all seats — a
+            # capped row's final_gap is a full 4-seat verdict
+            partial = gap_exit and it != iters and not budget_stop
+            vbar, gap = measure(asig, partial)
             trace.append((it, gap))
             result = (asig, vbar, gap)
             if target_gap is not None and gap <= target_gap:
                 break
             if over():                 # budget-driven stop, gap just priced
-                capped = True
-                break
+                if not partial:
+                    capped = True
+                    break
+                # partial measurement can't cap: iterate on; the next
+                # boundary check sees the expired budget and prices fully
 
     asig_f, vbar, gap = result
     prof = export(asig_f)              # once, at the stop — not per measure

--- a/hoyt/cfr.py
+++ b/hoyt/cfr.py
@@ -327,7 +327,8 @@ class _WaveStruct:
 
 
 def _build_wave(root, worlds, weights, pinned: dict, slot_budget,
-                want_debug: bool, bulk_export: bool = False) -> _WaveStruct:
+                want_debug: bool, bulk_export: bool = False,
+                kernels: bool = False) -> _WaveStruct:
     from hoyt.subgame import (
         build_subgame as _kernel_subgame,
         expand_full_width,
@@ -339,10 +340,10 @@ def _build_wave(root, worlds, weights, pinned: dict, slot_budget,
     ksub = _kernel_subgame(root, worlds, weights)
     kw = {} if slot_budget is None else {"slot_budget": slot_budget}
     res = expand_full_width(ksub, keep_slots=True,
-                            need_path_ids=bulk_export, **kw)
+                            need_path_ids=bulk_export, kernels=kernels,
+                            **kw)
     waves = res["waves"]
     L = len(waves) - 1
-    N = int(ksub.worlds.shape[0])
     me = ksub.me
     col_arr = ksub.col_arr
     LED, CFB = ksub.LED, ksub.CFB
@@ -383,15 +384,14 @@ def _build_wave(root, worlds, weights, pinned: dict, slot_budget,
 
     for j in range(L):
         wj, wn = waves[j], waves[j + 1]
-        snode, sworld, sw = wj["snode"], wj["sworld"], wj["sw"]
+        snode, sw = wj["snode"], wj["sw"]
         parn = wn["parent"]                       # int32: index use only
         tile_n = wn["tile"].astype(np.int64)      # int8 stored; arithmetic
         pseat_n = wn["pseat"].astype(np.int64)    # needs the wide dtype
         Mj = len(wj["counts"])
 
-        # actor per wave-j node = seat of its first child edge
-        firstchild = np.searchsorted(parn, np.arange(Mj))
-        actor_n = pseat_n[firstchild]
+        # actor per wave-j node: resident from the walk (int8 stored)
+        actor_n = wj["actor"].astype(np.int64)
 
         # acting hand per slot (me's hand is node-public, replayed)
         acts = actor_n[snode]
@@ -415,22 +415,13 @@ def _build_wave(root, worlds, weights, pinned: dict, slot_budget,
         nleg = np.bitwise_count(lm.astype(np.uint64)).astype(np.int64)
         off = Lflat + np.concatenate(([0], np.cumsum(nleg)))[:-1]
 
-        # child edges -> parent slots, by (node, world) key (worlds are
-        # unique within a node and node-major slot order is preserved)
-        snode_c, sworld_c = wn["snode"], wn["sworld"]
+        # child edges -> parent slots: resident from the walk (rows/gidx,
+        # perf-log 18n; formerly re-derived by (node, world) key search —
+        # 2 s of searchsorted on the anchor)
+        snode_c = wn["snode"]
         TC = tile_n[snode_c]
         seat_e = pseat_n[snode_c]
-        kp = snode.astype(np.int64) * N + sworld
-        kc = parn[snode_c].astype(np.int64) * N + sworld_c
-        if kp.size > 1 and not (kp[1:] > kp[:-1]).all():
-            sp = np.argsort(kp, kind="stable")
-            PS = sp[np.searchsorted(kp[sp], kc)]
-        else:
-            PS = np.searchsorted(kp, kc)
-        if not np.array_equal(kp[PS], kc):
-            raise AssertionError(
-                f"wave {j}: parent-slot reconstruction failed (kernel wave "
-                "ordering changed?)")
+        PS = wn["pslot"].astype(np.int64)
         # cross-check: the walk's edge fan-out must equal LUT legality
         cnt_edges = np.bincount(PS, minlength=ws.S[j])
         if not np.array_equal(cnt_edges[fidx], nleg):
@@ -541,8 +532,10 @@ def _build_wave(root, worlds, weights, pinned: dict, slot_budget,
 
         # free the slot-level memory hogs as soon as the transition is done
         wj["sw"] = wj["snode"] = wj["sworld"] = None
+        wj["pslot"] = wj["actor"] = None
 
     waves[L]["sw"] = waves[L]["snode"] = waves[L]["sworld"] = None
+    waves[L]["pslot"] = None
     ws.n_isets = n_isets
     ws.Lflat = Lflat
     if bulk_export:
@@ -943,7 +936,8 @@ def _solve_wave(subgame, payoff43, iters, target_gap, br_every, impl,
     t0 = time.time()
     ws = _build_wave(subgame.root, subgame.worlds, subgame.weights, pinned,
                      slot_budget, debug,
-                     bulk_export=hasattr(impl.StochasticProfile, "set_bulk"))
+                     bulk_export=hasattr(impl.StochasticProfile, "set_bulk"),
+                     kernels=fused)
 
     bid_team = int(subgame.root.bidder) % 2
     signs = {u: sign_of(u, bid_team) for u in range(4)}

--- a/hoyt/cfr.py
+++ b/hoyt/cfr.py
@@ -36,16 +36,30 @@ seats, per world); an info set's own-reach is constant across its worlds
 (its seat's past probabilities are pinned by the public path), which the
 implementation exploits.
 
-Two interchangeable iteration engines (identical math, parity-gated in
-walt/tests/test_cfr_parity.py):
+Three interchangeable iteration engines (identical math, parity-gated in
+hoyt/tests/test_cfr_parity.py):
 
-- engine="wave" (default): the static public tree + info-set index is
-  reconstructed from `hoyt.expand_full_width`'s SoA waves (parent
-  slots matched by sorted (node, world) keys; per-edge strategy slots by
-  masked-popcount move ranks against per-info-set legality). Iterations are
-  pure per-wave gathers + bincounts — zero python per-node work.
+- engine="fused" (default): numba edge kernels (hoyt/iterkernel.py) over
+  the wave engine's structure, with native int32 indices, forced-edge
+  skips, and a FORCED-SLOT-COMPRESSED strategy space (#82). Forced info
+  sets (single legal move, ~83% at H4 scale) are provably inert in RM+:
+  their sigma is exactly 1.0 forever and their regret update is exactly
+  0.0 (cf - cfv == 0 on a single-slot iset), so reg/avg/cf/xI live only on
+  non-forced slots, grouped per seat so each seat's update is a contiguous
+  slice. fp64 results are BITWISE identical to engine="wave".
+- engine="wave": the numpy vectorized engine over the static public tree +
+  info-set index reconstructed from `hoyt.expand_full_width`'s SoA waves
+  (parent slots matched by sorted (node, world) keys; per-edge strategy
+  slots by masked-popcount move ranks against per-info-set legality).
+  Iterations are pure per-wave gathers + bincounts — zero python per-node
+  work. Kept as the pinned pure-numpy mirror for the fused lane.
 - engine="loop": the original recursive python traversal, kept verbatim as
   the verified correctness mirror for parity tests. Toy sizes only.
+
+The fused lane is fp64 only: an fp32 dtype knob was built and measured
+dead on the anchor (P7 refuted — gap drift 2.6e-3 over the 1e-3 license
+bar AND zero throughput win; the fused loops are gather-latency-bound,
+not float-bandwidth-bound). Receipts: wiki perf-log 18l.
 
 Exported profiles skip FORCED decisions (single legal move): both BR
 implementations play forced moves without consulting the profile, so
@@ -597,13 +611,169 @@ def _wave_pass(ws: _WaveStruct, sig, u, payleaf, cf, xI) -> None:
 
 
 # =========================================================================== #
+#  engine="fused" — numba edge kernels + forced-slot-compressed updates (#82)  #
+# =========================================================================== #
+
+class _FusedLayout:
+    """Per-solve iterate layout for the fused engine, derived from a
+    _WaveStruct. Compressed slot space = non-forced slots only (nlegal >= 2),
+    stable-sorted by seat so each seat's slots and info sets are contiguous
+    slices; within a seat, slot and iset order match the flat wave-major
+    order, so per-iset accumulations happen in the same order as the wave
+    engine's bincounts (bitwise parity). Per wave: int32 parent slots,
+    int32 compressed strategy ids (-1 = forced edge), int8 edge seats."""
+
+    __slots__ = ("n_c", "n_ci", "c_flat", "c_soff", "c_isoff",
+                 "c_isl_loc", "inv_nleg", "sig0_full",
+                 "ps32", "cgid32", "eseat8", "c_iju", "w0",
+                 "rmu", "ru2", "v2")
+
+
+def _build_fused(ws: _WaveStruct, sig0_full) -> _FusedLayout:
+    fl = _FusedLayout()
+    nleg_iset = np.diff(np.append(ws.off, ws.Lflat))
+    slot_seat = ws.i_seat_arr[ws.slot_iset]
+    flat_idx = np.flatnonzero(nleg_iset[ws.slot_iset] >= 2)
+    order = np.argsort(slot_seat[flat_idx], kind="stable")
+    fl.c_flat = flat_idx[order]
+    c_seat = slot_seat[fl.c_flat]
+    fl.n_c = len(fl.c_flat)
+    fl.c_soff = np.searchsorted(c_seat, np.arange(5))
+    cmap = np.full(ws.Lflat, -1, dtype=np.int32)
+    cmap[fl.c_flat] = np.arange(fl.n_c, dtype=np.int32)
+
+    # compressed isets: contiguous slot runs, ascending within each seat
+    c_iset_g = ws.slot_iset[fl.c_flat]
+    starts = np.empty(fl.n_c, dtype=bool)
+    if fl.n_c:
+        starts[0] = True
+        starts[1:] = c_iset_g[1:] != c_iset_g[:-1]
+    c_isl = np.cumsum(starts) - 1              # global compressed iset id
+    fl.n_ci = int(c_isl[-1]) + 1 if fl.n_c else 0
+    fl.c_isoff = np.empty(5, dtype=np.int64)
+    fl.c_isoff[4] = fl.n_ci
+    for u in range(3, -1, -1):
+        lo = fl.c_soff[u]
+        fl.c_isoff[u] = c_isl[lo] if lo < fl.c_soff[u + 1] \
+            else fl.c_isoff[u + 1]
+    fl.c_isl_loc = c_isl - fl.c_isoff[c_seat]  # per-seat-local iset ids
+
+    # same ops as the wave engine's update (1.0 / nlegal), precomputed
+    fl.inv_nleg = 1.0 / ws.nlegal_slot[fl.c_flat]
+    fl.sig0_full = sig0_full                   # fp64; forced 1.0, pins set
+
+    imap = np.full(ws.n_isets, -1, dtype=np.int64)
+    if fl.n_c:
+        imap[c_iset_g[starts]] = np.arange(fl.n_ci)
+    fl.c_iju = {}
+    for (j, u), (ids, reps) in ws.iset_ju.items():
+        ci = imap[ids]
+        keep = ci >= 0
+        if keep.any():
+            fl.c_iju[(j, u)] = (ci[keep], reps[keep])
+
+    fl.ps32 = [p.astype(np.int32) for p in ws.PS]
+    fl.cgid32 = [cmap[g] for g in ws.GID]
+    fl.eseat8 = []
+    for j in range(ws.L):
+        e = np.empty(len(ws.PS[j]), dtype=np.int8)
+        for u, ue in ws.uedge[j].items():
+            e[ue] = u
+        fl.eseat8.append(e)
+
+    fl.w0 = ws.w0
+    fl.rmu = [np.empty(s) for s in ws.S]
+    max_s = max(ws.S)
+    fl.ru2 = (np.empty(max_s), np.empty(max_s))
+    fl.v2 = (np.empty(max_s), np.empty(max_s))
+
+    # warm the jit on 1-edge dummies so compile/cache-load lands in the
+    # build timing bucket, not the first iteration's
+    from hoyt.iterkernel import bwd_edges, fwd_edges
+    z32, f32 = np.zeros(1, np.int32), np.full(1, -1, np.int32)
+    z8 = np.zeros(1, np.int8)
+    d = np.ones(1)
+    fwd_edges(z32, f32, z8, 0, d, d.copy(), d.copy(),
+              np.empty(1), np.empty(1))
+    bwd_edges(z32, f32, z8, 0, d, d.copy(), d.copy(),
+              np.empty(1), d.copy())
+    return fl
+
+
+def _fused_pass(ws: _WaveStruct, fl: _FusedLayout, sig_c, u, payleaf,
+                cf_c, xI_c) -> None:
+    """One update traversal for seat u — the fused twin of _wave_pass."""
+    from hoyt.iterkernel import bwd_edges, fwd_edges
+    L = ws.L
+    fl.rmu[0][:] = fl.w0
+    ru = fl.ru2[0][:ws.S[0]]
+    ru[:] = 1.0
+    for j in range(L):
+        cj = fl.c_iju.get((j, u))
+        if cj is not None:
+            cids, reps = cj
+            xI_c[cids] = ru[reps]
+        ru_n = fl.ru2[(j + 1) & 1][:ws.S[j + 1]]
+        fwd_edges(fl.ps32[j], fl.cgid32[j], fl.eseat8[j], u, sig_c,
+                  fl.rmu[j], ru, fl.rmu[j + 1], ru_n)
+        ru = ru_n
+    v = fl.v2[L & 1][:ws.S[L]]
+    v[:] = payleaf
+    for j in range(L - 1, -1, -1):
+        v_p = fl.v2[j & 1][:ws.S[j]]
+        bwd_edges(fl.ps32[j], fl.cgid32[j], fl.eseat8[j], u, sig_c,
+                  v, fl.rmu[j], v_p, cf_c)
+        v = v_p
+
+
+def _rm_plus_update_c(fl: _FusedLayout, u, sig_c, reg_c, avg_c, cf_c, xI_c,
+                      sign_u, it) -> None:
+    """The CFR+ update block on seat u's compressed contiguous slice —
+    identical math (and, in fp64, identical bits) to _rm_plus_update
+    restricted to seat u's non-forced slots; forced slots are provably
+    inert there (reg == 0, sigma == 1 exactly), so nothing is lost."""
+    sl = slice(fl.c_soff[u], fl.c_soff[u + 1])
+    isl = fl.c_isl_loc[sl]
+    niu = int(fl.c_isoff[u + 1] - fl.c_isoff[u])
+    s = sig_c[sl]
+    c = cf_c[sl]
+    xIl = xI_c[fl.c_isoff[u]:fl.c_isoff[u + 1]]
+    cfv = np.bincount(isl, weights=s * c, minlength=niu)
+    avg_c[sl] += it * xIl[isl] * s
+    reg = np.maximum(reg_c[sl] + sign_u * (c - cfv[isl]), 0.0)
+    reg_c[sl] = reg
+    tot = np.bincount(isl, weights=reg, minlength=niu)
+    has = tot[isl] > 0
+    sig_c[sl] = np.where(has, reg / np.where(has, tot[isl], 1.0),
+                         fl.inv_nleg[sl])
+
+
+def _avg_sig_fused(fl: _FusedLayout, avg_c, live_seats) -> np.ndarray:
+    """Full-slot-space fp64 normalized average — bitwise what _avg_sig
+    returns: forced slots 1.0, pinned slots their fixed probs (both live in
+    sig0_full), live seats' non-forced slots avg/tot (uniform where the
+    iset was never reached)."""
+    out = fl.sig0_full.copy()
+    for u in live_seats:
+        sl = slice(fl.c_soff[u], fl.c_soff[u + 1])
+        isl = fl.c_isl_loc[sl]
+        niu = int(fl.c_isoff[u + 1] - fl.c_isoff[u])
+        a = avg_c[sl]
+        tot = np.bincount(isl, weights=a, minlength=niu)
+        has = tot[isl] > 0
+        out[fl.c_flat[sl]] = np.where(
+            has, a / np.where(has, tot[isl], 1.0), fl.inv_nleg[sl])
+    return out
+
+
+# =========================================================================== #
 #  cfr_solve                                                                   #
 # =========================================================================== #
 
 def cfr_solve(subgame, payoff43, iters: int = 200, target_gap: float | None = None,
               seed: int = 0, br_every: int = 10, impl=None,
               pinned: dict | None = None, debug: bool = False,
-              engine: str = "wave", slot_budget: int | None = None,
+              engine: str = "fused", slot_budget: int | None = None,
               wall_budget_s: float | None = None) -> CFRResult:
     """CFR+ over all four seats' info sets; gap priced by impl.br_solve.
 
@@ -624,8 +794,10 @@ def cfr_solve(subgame, payoff43, iters: int = 200, target_gap: float | None = No
             take no regret updates, and are excluded from the gap max
             (the 2-player-izable toy harness).
         debug: attach internals (regrets, average, iset table).
-        engine: "wave" (vectorized over the kernel's SoA walk, default) or
-            "loop" (the original recursive mirror, toy sizes only).
+        engine: "fused" (numba edge kernels + forced-slot-compressed
+            updates, default), "wave" (the pure-numpy mirror; fp64 results
+            are bitwise identical to fused), or "loop" (the original
+            recursive mirror, toy sizes only).
         slot_budget: forwarded to the kernel walk (wave engine); None keeps
             the kernel default. A KernelMemoryError means chunk or cap —
             escalate, never sample.
@@ -658,15 +830,17 @@ def cfr_solve(subgame, payoff43, iters: int = 200, target_gap: float | None = No
     if payoff43.shape[0] != 43:
         raise ValueError("payoff43 must have 43 entries")
     pinned = {int(s): p for s, p in (pinned or {}).items()}
-    if engine not in ("wave", "loop"):
-        raise ValueError(f"engine must be 'wave' or 'loop', got {engine!r}")
-    if wall_budget_s is not None and engine != "wave":
-        raise ValueError("wall_budget_s requires engine='wave' (the loop "
-                         "engine is the frozen parity mirror; wall-driven "
-                         "stops cannot be parity-pinned)")
-    if engine == "wave":
+    if engine not in ("fused", "wave", "loop"):
+        raise ValueError(
+            f"engine must be 'fused', 'wave' or 'loop', got {engine!r}")
+    if wall_budget_s is not None and engine == "loop":
+        raise ValueError("wall_budget_s requires engine='fused' or 'wave' "
+                         "(the loop engine is the frozen parity mirror; "
+                         "wall-driven stops cannot be parity-pinned)")
+    if engine in ("fused", "wave"):
         return _solve_wave(subgame, payoff43, iters, target_gap, br_every,
-                           impl, pinned, debug, slot_budget, wall_budget_s)
+                           impl, pinned, debug, slot_budget, wall_budget_s,
+                           fused=(engine == "fused"))
     return _solve_loop(subgame, payoff43, iters, target_gap, br_every,
                        impl, pinned, debug)
 
@@ -702,21 +876,19 @@ def _avg_sig(sig, avg, slot_iset, nlegal_slot, n_isets, unpinned_mask):
 
 
 def _solve_wave(subgame, payoff43, iters, target_gap, br_every, impl,
-                pinned, debug, slot_budget, wall_budget_s=None) -> CFRResult:
+                pinned, debug, slot_budget, wall_budget_s=None,
+                fused=False) -> CFRResult:
     tm = {"build": 0.0, "iterate": 0.0, "export": 0.0, "br": 0.0,
           "value": 0.0}
     t0 = time.time()
     ws = _build_wave(subgame.root, subgame.worlds, subgame.weights, pinned,
                      slot_budget, debug,
                      bulk_export=hasattr(impl.StochasticProfile, "set_bulk"))
-    tm["build"] = time.time() - t0
 
     bid_team = int(subgame.root.bidder) % 2
     signs = {u: sign_of(u, bid_team) for u in range(4)}
     payleaf = payoff43[ws.leaf_pts]
 
-    reg = np.zeros(ws.Lflat)
-    avg = np.zeros(ws.Lflat)
     sig = 1.0 / ws.nlegal_slot
     slot_pinned = np.zeros(ws.Lflat, dtype=bool)
     for off, probs in ws.pin_slots:
@@ -727,9 +899,21 @@ def _solve_wave(subgame, payoff43, iters, target_gap, br_every, impl,
         slot_seat = ws.i_seat_arr[ws.slot_iset]
         for s in pinned:
             slot_pinned |= (slot_seat == s)
-    slot_seat = ws.i_seat_arr[ws.slot_iset]
     live_seats = [u for u in range(4) if u not in pinned]
-    upd = {u: (slot_seat == u) & ~slot_pinned for u in live_seats}
+
+    if fused:
+        fl = _build_fused(ws, sig)
+        sig_c = sig[fl.c_flat].copy()
+        reg_c = np.zeros(fl.n_c)
+        avg_c = np.zeros(fl.n_c)
+        cf_c = np.zeros(fl.n_c)
+        xI_c = np.zeros(fl.n_ci)
+    else:
+        reg = np.zeros(ws.Lflat)
+        avg = np.zeros(ws.Lflat)
+        slot_seat = ws.i_seat_arr[ws.slot_iset]
+        upd = {u: (slot_seat == u) & ~slot_pinned for u in live_seats}
+    tm["build"] = time.time() - t0
 
     def export(asig):
         t1 = time.time()
@@ -766,20 +950,35 @@ def _solve_wave(subgame, payoff43, iters, target_gap, br_every, impl,
     capped = False
     over = (lambda: time.time() - t0 > wall_budget_s) \
         if wall_budget_s is not None else (lambda: False)
-    cf = np.empty(ws.Lflat)
-    xI = np.empty(ws.n_isets)
+    if not fused:
+        cf = np.empty(ws.Lflat)
+        xI = np.empty(ws.n_isets)
+
+    def averaged():
+        if fused:
+            return _avg_sig_fused(fl, avg_c, live_seats)
+        return _avg_sig(sig, avg, ws.slot_iset, ws.nlegal_slot,
+                        ws.n_isets, ~slot_pinned)
+
     for it in range(1, iters + 1):
         t1 = time.time()
-        for u in live_seats:
-            cf[:] = 0.0
-            xI[:] = 0.0
-            _wave_pass(ws, sig, u, payleaf, cf, xI)
-            _rm_plus_update(sig, reg, avg, cf, xI, upd[u], ws.slot_iset,
-                            ws.nlegal_slot, ws.n_isets, signs[u], it)
+        if fused:
+            for u in live_seats:
+                cf_c[fl.c_soff[u]:fl.c_soff[u + 1]] = 0.0
+                xI_c[fl.c_isoff[u]:fl.c_isoff[u + 1]] = 0.0
+                _fused_pass(ws, fl, sig_c, u, payleaf, cf_c, xI_c)
+                _rm_plus_update_c(fl, u, sig_c, reg_c, avg_c, cf_c, xI_c,
+                                  signs[u], it)
+        else:
+            for u in live_seats:
+                cf[:] = 0.0
+                xI[:] = 0.0
+                _wave_pass(ws, sig, u, payleaf, cf, xI)
+                _rm_plus_update(sig, reg, avg, cf, xI, upd[u], ws.slot_iset,
+                                ws.nlegal_slot, ws.n_isets, signs[u], it)
         tm["iterate"] += time.time() - t1
         if it % br_every == 0 or it == iters or over():
-            asig = _avg_sig(sig, avg, ws.slot_iset, ws.nlegal_slot,
-                            ws.n_isets, ~slot_pinned)
+            asig = averaged()
             prof, vbar, gap = measure(asig)
             trace.append((it, gap))
             result = (prof, vbar, gap)
@@ -792,11 +991,21 @@ def _solve_wave(subgame, payoff43, iters, target_gap, br_every, impl,
     prof, vbar, gap = result
     dbg = None
     if debug:
-        asig = _avg_sig(sig, avg, ws.slot_iset, ws.nlegal_slot, ws.n_isets,
-                        ~slot_pinned)
+        asig = averaged()
         isets = SimpleNamespace(
             off=ws.off, i_moves=ws.dbg["i_moves"], i_node=ws.dbg["i_node"],
             i_seat=ws.dbg["i_seat"], i_hand=ws.dbg["i_hand"])
+        if fused:
+            # scatter compressed state to full-slot space; forced slots
+            # carry their exact invariants (reg 0.0, sig 1.0). avg differs
+            # from the wave engine's on forced/unreached slots (dead weight
+            # there); avg_sig is the parity-meaningful surface.
+            reg = np.zeros(ws.Lflat)
+            reg[fl.c_flat] = reg_c
+            avg = np.zeros(ws.Lflat)
+            avg[fl.c_flat] = avg_c
+            sig = fl.sig0_full.copy()
+            sig[fl.c_flat] = sig_c
         dbg = {"isets": isets, "reg": reg, "avg": avg, "avg_sig": asig,
                "sig": sig, "n_isets": ws.n_isets}
     return CFRResult(profile=prof, trace=trace, gap=gap, value=vbar,

--- a/hoyt/cfr.py
+++ b/hoyt/cfr.py
@@ -1045,6 +1045,13 @@ def _solve_wave(subgame, payoff43, iters, target_gap, br_every, impl,
     tm = {"build": 0.0, "iterate": 0.0, "export": 0.0, "br": 0.0,
           "value": 0.0}
     t0 = time.time()
+    if fused and threads:
+        # set before the build, not just before _build_fused: any numba
+        # parallel kernel reached from _build_wave would otherwise run at
+        # numba's default (all cores) and oversubscribe a multi-worker
+        # sweep (perf-log 19d)
+        import numba
+        numba.set_num_threads(threads)
     ws = _build_wave(subgame.root, subgame.worlds, subgame.weights, pinned,
                      slot_budget, debug,
                      bulk_export=hasattr(impl.StochasticProfile, "set_bulk"),
@@ -1067,9 +1074,6 @@ def _solve_wave(subgame, payoff43, iters, target_gap, br_every, impl,
     live_seats = [u for u in range(4) if u not in pinned]
 
     if fused:
-        if threads:
-            import numba
-            numba.set_num_threads(threads)
         fl = _build_fused(ws, sig, par=bool(threads))
         sig_c = sig[fl.c_flat].copy()
         reg_c = np.zeros(fl.n_c)

--- a/hoyt/cfr.py
+++ b/hoyt/cfr.py
@@ -688,11 +688,12 @@ class _FusedLayout:
     __slots__ = ("n_c", "n_ci", "c_flat", "c_soff", "c_isoff",
                  "c_isl_loc", "inv_nleg", "sig0_full",
                  "ps32", "cgid32", "eseat8", "c_iju", "w0",
-                 "rmu", "ru2", "v2")
+                 "rmu", "ru2", "v2", "par", "vseg", "cf_ju", "iso")
 
 
-def _build_fused(ws: _WaveStruct, sig0_full) -> _FusedLayout:
+def _build_fused(ws: _WaveStruct, sig0_full, par: bool = False) -> _FusedLayout:
     fl = _FusedLayout()
+    fl.par = par
     nleg_iset = np.diff(np.append(ws.off, ws.Lflat))
     slot_seat = ws.i_seat_arr[ws.slot_iset]
     flat_idx = np.flatnonzero(nleg_iset[ws.slot_iset] >= 2)
@@ -749,6 +750,46 @@ def _build_fused(ws: _WaveStruct, sig0_full) -> _FusedLayout:
     fl.ru2 = (np.empty(max_s), np.empty(max_s))
     fl.v2 = (np.empty(max_s), np.empty(max_s))
 
+    if par:
+        # P13 threading structure: every parallel fold's grouping is built
+        # HERE, once, from the walk's arrays (stable argsorts) — the kernels
+        # then own disjoint output ranges with ascending-edge order inside
+        # each group, which makes them bitwise vs the sequential lane
+        # regardless of thread count or scheduling (see iterkernel.py).
+        fl.vseg = []
+        for j in range(ws.L):
+            ps = fl.ps32[j]
+            cnt = np.bincount(ps, minlength=ws.S[j])
+            if len(ps) == ws.S[j] and cnt.max() == 1:
+                fl.vseg.append(None)       # bijection wave: pure-map path
+            else:
+                poff = np.zeros(ws.S[j] + 1, dtype=np.int64)
+                np.cumsum(cnt, out=poff[1:])
+                perm = np.argsort(ps, kind="stable").astype(np.int32)
+                fl.vseg.append((poff, perm))
+        fl.cf_ju = {}
+        for j in range(ws.L):
+            e8, cg = fl.eseat8[j], fl.cgid32[j]
+            for u in range(4):
+                sel = np.flatnonzero((e8 == u) & (cg >= 0))
+                if not len(sel):
+                    continue
+                g = cg[sel]
+                o = np.argsort(g, kind="stable")
+                gs = g[o]
+                st = np.empty(len(gs), dtype=bool)
+                st[0] = True
+                st[1:] = gs[1:] != gs[:-1]
+                goff = np.append(np.flatnonzero(st),
+                                 len(gs)).astype(np.int64)
+                fl.cf_ju[(j, u)] = (goff, gs[st], sel[o].astype(np.int32))
+        fl.iso = {}
+        for u in range(4):
+            sl = slice(fl.c_soff[u], fl.c_soff[u + 1])
+            niu = int(fl.c_isoff[u + 1] - fl.c_isoff[u])
+            fl.iso[u] = np.searchsorted(
+                fl.c_isl_loc[sl], np.arange(niu + 1)).astype(np.int64)
+
     # warm the jit on 1-edge dummies so compile/cache-load lands in the
     # build timing bucket, not the first iteration's
     from hoyt.iterkernel import bwd_edges, fwd_edges
@@ -759,32 +800,57 @@ def _build_fused(ws: _WaveStruct, sig0_full) -> _FusedLayout:
               np.empty(1), np.empty(1))
     bwd_edges(z32, f32, z8, 0, d, d.copy(), d.copy(),
               np.empty(1), d.copy())
+    if par:
+        from hoyt.iterkernel import (bwd_v_map, bwd_v_seg, cf_seg,
+                                     fwd_edges_par, rm_update_seg)
+        z64 = np.zeros(2, np.int64)
+        fwd_edges_par(z32, f32, z8, 0, d, d.copy(), d.copy(),
+                      np.empty(1), np.empty(1))
+        bwd_v_map(z32, f32, d, d.copy(), np.empty(1))
+        bwd_v_seg(z64, z32, f32, d, d.copy(), np.empty(1))
+        cf_seg(z64, z32, z32, z32, d, d.copy(), np.empty(1))
+        rm_update_seg(z64, d.copy(), d.copy(), d.copy(), d.copy(),
+                      np.empty(0), d.copy(), 1, 1)
     return fl
 
 
 def _fused_pass(ws: _WaveStruct, fl: _FusedLayout, sig_c, u, payleaf,
                 cf_c, xI_c) -> None:
     """One update traversal for seat u — the fused twin of _wave_pass."""
-    from hoyt.iterkernel import bwd_edges, fwd_edges
+    from hoyt.iterkernel import (bwd_edges, bwd_v_map, bwd_v_seg, cf_seg,
+                                 fwd_edges, fwd_edges_par)
     L = ws.L
     fl.rmu[0][:] = fl.w0
     ru = fl.ru2[0][:ws.S[0]]
     ru[:] = 1.0
+    fwd = fwd_edges_par if fl.par else fwd_edges
     for j in range(L):
         cj = fl.c_iju.get((j, u))
         if cj is not None:
             cids, reps = cj
             xI_c[cids] = ru[reps]
         ru_n = fl.ru2[(j + 1) & 1][:ws.S[j + 1]]
-        fwd_edges(fl.ps32[j], fl.cgid32[j], fl.eseat8[j], u, sig_c,
-                  fl.rmu[j], ru, fl.rmu[j + 1], ru_n)
+        fwd(fl.ps32[j], fl.cgid32[j], fl.eseat8[j], u, sig_c,
+            fl.rmu[j], ru, fl.rmu[j + 1], ru_n)
         ru = ru_n
     v = fl.v2[L & 1][:ws.S[L]]
     v[:] = payleaf
     for j in range(L - 1, -1, -1):
         v_p = fl.v2[j & 1][:ws.S[j]]
-        bwd_edges(fl.ps32[j], fl.cgid32[j], fl.eseat8[j], u, sig_c,
-                  v, fl.rmu[j], v_p, cf_c)
+        if fl.par:
+            cfj = fl.cf_ju.get((j, u))
+            if cfj is not None:
+                goff, gids, perm = cfj
+                cf_seg(goff, gids, perm, fl.ps32[j], fl.rmu[j], v, cf_c)
+            seg = fl.vseg[j]
+            if seg is None:
+                bwd_v_map(fl.ps32[j], fl.cgid32[j], sig_c, v, v_p)
+            else:
+                poff, vperm = seg
+                bwd_v_seg(poff, vperm, fl.cgid32[j], sig_c, v, v_p)
+        else:
+            bwd_edges(fl.ps32[j], fl.cgid32[j], fl.eseat8[j], u, sig_c,
+                      v, fl.rmu[j], v_p, cf_c)
         v = v_p
 
 
@@ -795,6 +861,12 @@ def _rm_plus_update_c(fl: _FusedLayout, u, sig_c, reg_c, avg_c, cf_c, xI_c,
     restricted to seat u's non-forced slots; forced slots are provably
     inert there (reg == 0, sigma == 1 exactly), so nothing is lost."""
     sl = slice(fl.c_soff[u], fl.c_soff[u + 1])
+    if fl.par:
+        from hoyt.iterkernel import rm_update_seg
+        rm_update_seg(fl.iso[u], sig_c[sl], reg_c[sl], avg_c[sl], cf_c[sl],
+                      xI_c[fl.c_isoff[u]:fl.c_isoff[u + 1]],
+                      fl.inv_nleg[sl], sign_u, it)
+        return
     isl = fl.c_isl_loc[sl]
     niu = int(fl.c_isoff[u + 1] - fl.c_isoff[u])
     s = sig_c[sl]
@@ -837,7 +909,8 @@ def cfr_solve(subgame, payoff43, iters: int = 200, target_gap: float | None = No
               pinned: dict | None = None, debug: bool = False,
               engine: str = "fused", slot_budget: int | None = None,
               wall_budget_s: float | None = None,
-              gap_exit: bool = False) -> CFRResult:
+              gap_exit: bool = False,
+              threads: int | None = None) -> CFRResult:
     """CFR+ over all four seats' info sets; gap priced by impl.br_solve.
 
     Args:
@@ -893,6 +966,13 @@ def cfr_solve(subgame, payoff43, iters: int = 200, target_gap: float | None = No
             record the certified-above-target partial max). Deterministic.
             wave/fused only: partial intermediate traces can't be
             parity-pinned against the loop mirror, so the loop raises.
+        threads: run the fused iterate kernels on this many numba threads
+            (perf-log P13). Bitwise identical to threads=None by
+            construction — every parallel fold owns a disjoint output range
+            with unchanged within-range accumulation order (the grouping is
+            precomputed structure in _build_fused, never a runtime
+            heuristic). Fused-only: the wave/loop mirrors are the pinned
+            single-threaded references, so they raise.
     """
     del seed  # deterministic full-width solve; kept for contract stability
     if impl is None:
@@ -916,10 +996,15 @@ def cfr_solve(subgame, payoff43, iters: int = 200, target_gap: float | None = No
         raise ValueError("gap_exit requires engine='fused' or 'wave' "
                          "(partial intermediate traces cannot be "
                          "parity-pinned against the loop mirror)")
+    if threads is not None and engine != "fused":
+        raise ValueError("threads requires engine='fused' (the wave and "
+                         "loop mirrors are the pinned single-threaded "
+                         "parity references)")
     if engine in ("fused", "wave"):
         return _solve_wave(subgame, payoff43, iters, target_gap, br_every,
                            impl, pinned, debug, slot_budget, wall_budget_s,
-                           fused=(engine == "fused"), gap_exit=gap_exit)
+                           fused=(engine == "fused"), gap_exit=gap_exit,
+                           threads=threads)
     return _solve_loop(subgame, payoff43, iters, target_gap, br_every,
                        impl, pinned, debug)
 
@@ -956,7 +1041,7 @@ def _avg_sig(sig, avg, slot_iset, nlegal_slot, n_isets, unpinned_mask):
 
 def _solve_wave(subgame, payoff43, iters, target_gap, br_every, impl,
                 pinned, debug, slot_budget, wall_budget_s=None,
-                fused=False, gap_exit=False) -> CFRResult:
+                fused=False, gap_exit=False, threads=None) -> CFRResult:
     tm = {"build": 0.0, "iterate": 0.0, "export": 0.0, "br": 0.0,
           "value": 0.0}
     t0 = time.time()
@@ -982,7 +1067,10 @@ def _solve_wave(subgame, payoff43, iters, target_gap, br_every, impl,
     live_seats = [u for u in range(4) if u not in pinned]
 
     if fused:
-        fl = _build_fused(ws, sig)
+        if threads:
+            import numba
+            numba.set_num_threads(threads)
+        fl = _build_fused(ws, sig, par=bool(threads))
         sig_c = sig[fl.c_flat].copy()
         reg_c = np.zeros(fl.n_c)
         avg_c = np.zeros(fl.n_c)

--- a/hoyt/iterkernel.py
+++ b/hoyt/iterkernel.py
@@ -22,9 +22,11 @@ float-bandwidth-bound). Receipts in wiki perf-log 18l.
 """
 from __future__ import annotations
 
-from numba import njit
+from numba import njit, prange
 
-__all__ = ["fwd_edges", "bwd_edges"]
+__all__ = ["fwd_edges", "bwd_edges",
+           "fwd_edges_par", "bwd_v_map", "bwd_v_seg", "cf_seg",
+           "rm_update_seg"]
 
 
 @njit(cache=True, boundscheck=False)
@@ -69,3 +71,99 @@ def bwd_edges(ps, cgid, eseat, u, sig_c, v_c, rmu_p, v_p, cf_c):
             v_p[p] += sig_c[g] * vc
         else:
             v_p[p] += vc
+
+
+# --------------------------------------------------------------------------- #
+#  parallel lane (P13) — same folds, disjoint outputs per prange iteration    #
+# --------------------------------------------------------------------------- #
+# The bitwise doctrine survives threading because every prange iteration owns
+# a DISJOINT output range and accumulates its contributions in the SAME
+# ascending-edge order as the sequential kernels (= np.bincount's fold). The
+# grouping that makes outputs disjoint is precomputed structure built once in
+# _build_fused (stable argsorts), never a runtime heuristic — so results are
+# bitwise identical regardless of thread count or scheduling. Register
+# accumulators seeded at +0.0 store the exact sequential fold: a +0.0-seeded
+# IEEE sum can never produce -0.0, so acc == (0.0 + t1) + t2 + ... bitwise.
+# numba's default strict IEEE mode (no fastmath) holds for parallel=True.
+
+
+@njit(cache=True, parallel=True, boundscheck=False)
+def fwd_edges_par(ps, cgid, eseat, u, sig_c, rmu_p, ru_p, rmu_c, ru_c):
+    """fwd_edges, threaded: a pure map — edge i writes only rmu_c[i]/ru_c[i],
+    so any chunking is bitwise."""
+    for i in prange(ps.shape[0]):
+        p = ps[i]
+        g = cgid[i]
+        pr = sig_c[g] if g >= 0 else 1.0
+        if eseat[i] == u:
+            rmu_c[i] = rmu_p[p]
+            ru_c[i] = ru_p[p] * pr
+        else:
+            rmu_c[i] = rmu_p[p] * pr
+            ru_c[i] = ru_p[p]
+
+
+@njit(cache=True, parallel=True, boundscheck=False)
+def bwd_v_map(ps, cgid, sig_c, v_c, v_p):
+    """Backward v for bijection waves (each parent has exactly ONE edge —
+    the trick-tail waves): a pure map. 0.0 + t reproduces the sequential
+    zero-then-accumulate fold exactly (incl. the sign of zero)."""
+    for i in prange(ps.shape[0]):
+        g = cgid[i]
+        vc = v_c[i]
+        v_p[ps[i]] = 0.0 + (sig_c[g] * vc if g >= 0 else vc)
+
+
+@njit(cache=True, parallel=True, boundscheck=False)
+def bwd_v_seg(poff, perm, cgid, sig_c, v_c, v_p):
+    """Backward v for general waves: parent p owns edges
+    perm[poff[p]:poff[p+1]] (stable argsort of PS — ascending edge order
+    within each parent, the bincount fold)."""
+    for p in prange(v_p.shape[0]):
+        acc = 0.0
+        for k in range(poff[p], poff[p + 1]):
+            i = perm[k]
+            g = cgid[i]
+            acc += sig_c[g] * v_c[i] if g >= 0 else v_c[i]
+        v_p[p] = acc
+
+
+@njit(cache=True, parallel=True, boundscheck=False)
+def cf_seg(goff, gids, perm, ps, rmu_p, v_c, cf_c):
+    """Counterfactual accumulation for the updating seat: group gl owns the
+    seat's non-forced edges of one strategy slot, ascending edge order
+    (stable argsort of cgid). cf_c is zeroed before the pass and each gid
+    lives in exactly one wave, so the store is the full sequential fold."""
+    for gl in prange(gids.shape[0]):
+        acc = 0.0
+        for k in range(goff[gl], goff[gl + 1]):
+            i = perm[k]
+            acc += rmu_p[ps[i]] * v_c[i]
+        cf_c[gids[gl]] = acc
+
+
+@njit(cache=True, parallel=True, boundscheck=False)
+def rm_update_seg(iso, sig_u, reg_u, avg_u, cf_u, xI_u, inv_u, sign_u, it):
+    """The CFR+ update block, threaded by info set: iset iu owns the
+    contiguous slot run iso[iu]:iso[iu+1] and every fold is iset-local
+    (cfv and tot in ascending slot order = the bincount fold; the clamp
+    matches np.maximum's +0.0 on ties)."""
+    for iu in prange(xI_u.shape[0]):
+        a, b = iso[iu], iso[iu + 1]
+        cfv = 0.0
+        for k in range(a, b):
+            cfv += sig_u[k] * cf_u[k]
+        txv = it * xI_u[iu]
+        for k in range(a, b):
+            avg_u[k] += txv * sig_u[k]
+            r = reg_u[k] + sign_u * (cf_u[k] - cfv)
+            reg_u[k] = r if r > 0.0 else 0.0
+        tot = 0.0
+        for k in range(a, b):
+            tot += reg_u[k]
+        if tot > 0.0:
+            for k in range(a, b):
+                sig_u[k] = reg_u[k] / tot
+        else:
+            for k in range(a, b):
+                sig_u[k] = inv_u[k]

--- a/hoyt/iterkernel.py
+++ b/hoyt/iterkernel.py
@@ -1,0 +1,71 @@
+"""hoyt/iterkernel.py — fused per-wave edge kernels for the CFR iterate.
+
+The engine="fused" lane of hoyt/cfr.py (#82): single-threaded numba loops
+that replicate the numpy wave engine's exact accumulation order, so fp64
+results are BITWISE identical to engine="wave" (the pinned mirror) — the
+gathers and multiplies are elementwise (same rounding), and every
+accumulation target receives its contributions in ascending edge order,
+which is precisely np.bincount's summation order. numba's default strict
+IEEE mode (no fastmath) keeps multiplies and adds separate, so no FMA
+contraction can perturb the last ulp.
+
+Why fused: the numpy iterate is memory-bandwidth-bound (perf-log 18g/18k).
+Per edge these kernels read int32 indices (half the int64 tax), skip the
+sigma gather entirely on FORCED edges (sigma == 1.0 forever, ~70% of edges
+at H4 scale — cgid < 0 encodes them), and never materialize the pr/pm/pu
+edge temporaries that each cost a DRAM round trip in numpy.
+
+fp64 only, deliberately: an fp32 lane was built and measured dead on the
+2026-07-18 anchor (P7 refuted — gap drift 2.6e-3 > the 1e-3 license bar,
+AND zero throughput win: the fused loops are gather-latency-bound, not
+float-bandwidth-bound). Receipts in wiki perf-log 18l.
+"""
+from __future__ import annotations
+
+from numba import njit
+
+__all__ = ["fwd_edges", "bwd_edges"]
+
+
+@njit(cache=True, boundscheck=False)
+def fwd_edges(ps, cgid, eseat, u, sig_c, rmu_p, ru_p, rmu_c, ru_c):
+    """One wave transition of the forward reach pass for updating seat u.
+
+    Mirrors (bitwise, fp64): pr = sig[GID]; pm = pr.copy(); pm[ue] = 1.0;
+    r_mu = r_mu[PS] * pm; pu = ones; pu[ue] = pr[ue]; r_u = r_u[PS] * pu.
+    x * 1.0 == x bitwise, so the skipped multiplies are exact.
+    """
+    for i in range(ps.shape[0]):
+        p = ps[i]
+        g = cgid[i]
+        pr = sig_c[g] if g >= 0 else 1.0
+        if eseat[i] == u:
+            rmu_c[i] = rmu_p[p]
+            ru_c[i] = ru_p[p] * pr
+        else:
+            rmu_c[i] = rmu_p[p] * pr
+            ru_c[i] = ru_p[p]
+
+
+@njit(cache=True, boundscheck=False)
+def bwd_edges(ps, cgid, eseat, u, sig_c, v_c, rmu_p, v_p, cf_c):
+    """One wave transition of the backward value pass for updating seat u.
+
+    Mirrors (bitwise, fp64): cf[slot] += bincount(GID[ue], r_mu[PS[ue]]*v[ue])
+    and v = bincount(PS, sig[GID]*v) — both accumulate in ascending edge
+    order, which this loop reproduces. cf on FORCED slots is provably inert
+    in RM+ (single-slot iset: cf - cfv == 0 exactly), so cgid < 0 edges skip
+    it; they also skip the sigma gather (sigma == 1.0).
+    """
+    for i in range(v_p.shape[0]):
+        v_p[i] = 0.0
+    for i in range(ps.shape[0]):
+        p = ps[i]
+        g = cgid[i]
+        vc = v_c[i]
+        if g >= 0:
+            if eseat[i] == u:
+                cf_c[g] += rmu_p[p] * vc
+            v_p[p] += sig_c[g] * vc
+        else:
+            v_p[p] += vc

--- a/hoyt/profiles.py
+++ b/hoyt/profiles.py
@@ -397,7 +397,18 @@ class _UniformProvider:
 
 class _FullWidthProvider:
     """All legal moves per slot, weights unscaled — the CFR structural
-    walk (reachability only; profile probabilities are the CFR lane's)."""
+    walk (reachability only; profile probabilities are the CFR lane's).
+
+    kernels=True emits (slot, move) via the numba fill (buildkernel.py,
+    the fused lane); the numpy bm/nonzero path is the pinned mirror —
+    identical output by construction (ascending (slot, move), integer
+    structure), and the wave lane stays numba-free."""
+
+    def __init__(self, kernels: bool = False):
+        self.kernels = kernels
+        if kernels:
+            from hoyt.buildkernel import fw_fill
+            self._fill = fw_fill
 
     def expand(self, eng, p, pos, sel, nsl, seats, hands):
         sub = eng.sub
@@ -405,6 +416,13 @@ class _FullWidthProvider:
         fb = np.where(ls >= 0, sub.CFB[ls], _ALL28)
         lm = hands & fb
         lm = np.where(lm != 0, lm, hands)
+        if self.kernels:
+            cnt = np.bitwise_count(lm.astype(np.uint64)).astype(np.int64)
+            off = np.concatenate(([0], np.cumsum(cnt)))
+            si = np.empty(off[-1], dtype=np.int64)
+            mv = np.empty(off[-1], dtype=np.int64)
+            self._fill(lm, off, si, mv)
+            return sel[si], mv, None, None
         bm = ((lm[:, None] >> _AR28) & 1).astype(bool)
         si, mv = np.nonzero(bm)
         return sel[si], mv.astype(np.int64), None, None

--- a/hoyt/refsweep.py
+++ b/hoyt/refsweep.py
@@ -224,8 +224,10 @@ def solve_root(rec: dict, rung: Rung, rung_idx: int, cap: int,
     """One (root, rung) -> one ledger row. The pipeline mirrors the ad-hoc
     2026-07-18 sweep worker (enumerate_worlds -> sigma_consistent ->
     deterministic world cap -> build_subgame -> compile_sigma -> walt BR ->
-    cfr_solve -> profile_value); caps and failures are first-class rows
-    instead of inline retries."""
+    cfr_solve); caps and failures are first-class rows instead of inline
+    retries. cfr_reference_value = res.value (profile_value survives only
+    as the deterministic 1-in-20 audit, P9); non-CFR phase walls land in
+    row["phase_s"] (perf-log 18m: the oracle bucket was un-instrumented)."""
     import resource
 
     import numpy as np
@@ -241,11 +243,14 @@ def solve_root(rec: dict, rung: Rung, rung_idx: int, cap: int,
                  "rung_spec": rung.spec(),
                  "me_declares": root.me % 2 == root.bidder % 2}
     t0 = time.perf_counter()
+    ph: dict = {}                     # non-CFR phase walls (perf-log 18m)
     try:
         pay = K.payoff_points()
+        t1 = time.perf_counter()
         worlds = enumerate_worlds(root)
         keep = sigma_consistent(root, worlds, oracle,
                                 _make_moves_filter(root))
+        ph["worlds"] = round(time.perf_counter() - t1, 2)
         w = worlds[keep] if keep.any() else worlds
         row["worlds_true"] = int(len(w))
         if len(w) > cap:
@@ -255,14 +260,30 @@ def solve_root(rec: dict, rung: Rung, rung_idx: int, cap: int,
         row["worlds_used"] = int(len(w))
         wt = np.full(len(w), 1.0 / len(w))
         sub = K.build_subgame(root, w, wt)
+        t1 = time.perf_counter()
         tab = K.compile_sigma(root, w, oracle)
+        ph["compile_sigma"] = round(time.perf_counter() - t1, 2)
+        t1 = time.perf_counter()
         br = K.br_solve(sub, tab, pay, slot_budget=rung.slot_budget)
+        ph["walt_br"] = round(time.perf_counter() - t1, 2)
         res = cfr_solve(sub, pay, iters=rung.iters,
                         target_gap=rung.target_gap, br_every=BR_EVERY,
                         wall_budget_s=rung.wall_budget_s,
                         slot_budget=rung.slot_budget)
-        ref_val = K.profile_value(sub, res.profile, pay,
-                                  slot_budget=rung.slot_budget)
+        # the reference value IS the solve's self-play value (measured
+        # identical on all 200 banked rows, delta 0.0); profile_value's
+        # full stochastic re-walk survives only as a 1-in-20 audit (P9)
+        ref_val = res.value
+        if rec["seed"] % 20 == 0:
+            t1 = time.perf_counter()
+            pv = K.profile_value(sub, res.profile, pay,
+                                 slot_budget=rung.slot_budget)
+            ph["audit_profile_value"] = round(time.perf_counter() - t1, 2)
+            row["audit_pv_delta"] = abs(pv - res.value)
+            if row["audit_pv_delta"] > 1e-9:
+                raise AssertionError(
+                    f"profile_value audit failed: {pv} vs res.value "
+                    f"{res.value} (P9 — put per-root pricing back)")
         sign = 1.0 if row["me_declares"] else -1.0
         row.update(
             verdict=("converged" if res.gap <= rung.target_gap
@@ -276,6 +297,7 @@ def solve_root(rec: dict, rung: Rung, rung_idx: int, cap: int,
             final_gap=round(res.gap, 6),
             trace=[(i, round(g, 6)) for i, g in res.trace],
             timings={k: round(v, 2) for k, v in res.timings.items()},
+            phase_s=ph,
         )
     except K.KernelMemoryError as e:
         row.update(verdict="slot_capped", error=repr(e)[:300])

--- a/hoyt/refsweep.py
+++ b/hoyt/refsweep.py
@@ -78,6 +78,13 @@ VERDICT_RANK = {"converged": 0, "gap_capped": 1, "slot_capped": 2, "error": 3}
 USABLE = ("converged", "gap_capped")
 BR_EVERY = 10            # gap-measure cadence (18o: denser is affordable
 #                          with gap_exit — intermediates price ~1 seat)
+THREADS = 4              # numba threads per worker for the fused iterate
+#                          (P13). Measured on the 20-root paired sweep,
+#                          5 workers, M5 Max: rung-0 wall 279.1 (t1) ->
+#                          245.9 (t2) -> 221.8 (t4) -> 215.4 (t8); t8's
+#                          gain over t4 is inside the +-4% noise floor at
+#                          40 threads on 18 cores, so 4 is the default.
+#                          Bitwise identical at any thread count.
 GIB_PER_32M = 7.0        # measured cap-256 worker peak RSS at 32M slots (18g)
 
 
@@ -221,7 +228,7 @@ def _root_of(rd: dict):
 
 
 def solve_root(rec: dict, rung: Rung, rung_idx: int, cap: int,
-               oracle) -> dict:
+               oracle, threads: int | None = None) -> dict:
     """One (root, rung) -> one ledger row. The pipeline mirrors the ad-hoc
     2026-07-18 sweep worker (enumerate_worlds -> sigma_consistent ->
     deterministic world cap -> build_subgame -> compile_sigma -> walt BR ->
@@ -271,7 +278,8 @@ def solve_root(rec: dict, rung: Rung, rung_idx: int, cap: int,
                         target_gap=rung.target_gap, br_every=BR_EVERY,
                         gap_exit=True,
                         wall_budget_s=rung.wall_budget_s,
-                        slot_budget=rung.slot_budget)
+                        slot_budget=rung.slot_budget,
+                        threads=threads)
         # the reference value IS the solve's self-play value (measured
         # identical on all 200 banked rows, delta 0.0); profile_value's
         # full stochastic re-walk survives only as a 1-in-20 audit (P9)
@@ -328,7 +336,8 @@ def _worker_main(a) -> int:
             rec = recs[seed]
             print(f"seed {seed} start "
                   f"(worlds_sigma={rec['n_worlds_sigma']})", flush=True)
-            row = solve_root(rec, rung, a.worker_rung, a.cap, oracle)
+            row = solve_root(rec, rung, a.worker_rung, a.cap, oracle,
+                             threads=a.threads or None)
             fh.write(json.dumps(row) + "\n")
             fh.flush()
             print(f"seed {seed} {row['verdict']} wall={row['wall_s']}s "
@@ -498,7 +507,8 @@ def _driver_main(a) -> int:
                    "--worker-rung", str(r), "--shard", str(w),
                    "--seeds", ",".join(map(str, seeds)),
                    "--cap", str(a.cap), "--outdir", str(outdir),
-                   "--evalset", str(evalset), "--net", a.net]
+                   "--evalset", str(evalset), "--net", a.net,
+                   "--threads", str(a.threads)]
             if a.rungs:
                 cmd += ["--rungs", a.rungs]
             procs.append(subprocess.Popen(cmd, stdout=log,
@@ -531,6 +541,11 @@ def main(argv=None) -> int:
     ap.add_argument("--net", default="champion/jud_net.pt")
     ap.add_argument("--seeds", default="",
                     help="restrict to these seeds (smoke runs)")
+    ap.add_argument("--threads", type=int, default=THREADS,
+                    help="numba threads per worker for the fused iterate "
+                         "(P13; 0 = single-threaded kernels). Bitwise "
+                         "identical either way; compose workers x threads "
+                         "against the core budget")
     ap.add_argument("--dry-run", action="store_true",
                     help="print ladder + resume state + shard plan, no solving")
     # worker mode (spawned by the driver; not a user surface)

--- a/hoyt/refsweep.py
+++ b/hoyt/refsweep.py
@@ -41,11 +41,18 @@ Resume unions every rung*_shard*.jsonl in --outdir and is verdict-aware: a
 converged row retires the root; any other verdict is done for ITS rung and
 a survivor for the next; a (root, rung) with a row is never re-entered.
 
-Sharding: sort ascending by n_worlds_sigma, deal round-robin (every queue
-spans the full size range), then rotate queue w by w/W of its length so
-monster phases stagger across workers. The snake this replaces both
-rank-aligned monster phases across workers AND let one 64M-slot root block
-~20 cheap queued roots for ~21 min (observed, 2026-07-18 ad-hoc sweep).
+Dispatch: one shared queue ordered by descending n_worlds_sigma, pull-based
+— every worker gets the full rung queue and claims one root at a time via
+atomic claim-file creation. Balance comes from the PULL, not from cost
+precision: paired arms measured static partitions (the round-robin snake)
+at 1.16-1.18x worse rung-0 makespan, and a sharper cost key (banked wall_s,
+rank-corr 0.889) actually LOST to sigma order — exact ranking front-loads
+the true monsters into simultaneous residency and pays ~14% per-seed
+contention inflation, while sigma's noisy ranking decorrelates the heavy
+phases (perf-log 19i; the old snake's stagger insight, reborn inside the
+pull). A worker that dies mid-solve orphans that root's claim for the run;
+the resume retries it, exactly as it retried a dead shard's unfinished
+queue.
 
 CLI (run from the repo root; the driver spawns per-shard subprocess
 workers, torch pinned to 1 thread, heartbeat every 30 s):
@@ -68,6 +75,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import shutil
 import subprocess
 import sys
 import time
@@ -126,26 +134,25 @@ def parse_rungs(spec: str) -> tuple[Rung, ...]:
 #  pure ladder logic (unit-tested without solving)                            #
 # =========================================================================== #
 
-def plan_shards(sized_seeds: list[tuple[int, int]],
-                workers: int) -> list[list[int]]:
-    """[(seed, n_worlds_sigma)] -> per-worker seed queues.
+def dispatch_order(sized_seeds: list[tuple[int, int]]) -> list[int]:
+    """[(seed, n_worlds_sigma)] -> ONE biggest-first queue shared by every
+    worker. Biggest-first because a long root dispatched late is pure
+    tail: the fleet idles behind it. Deterministic; ties break by seed."""
+    return [s for s, _ in sorted(sized_seeds, key=lambda t: (-t[1], t[0]))]
 
-    Sort ascending by size, deal round-robin (queue w = ranks w, w+W, ... —
-    every queue spans the full size range), then rotate queue w by w/W of
-    its length: worker 0 runs small->monster, worker w starts w/W of the
-    way up the size range, so at any moment roughly one worker is in its
-    monster phase instead of all of them at once. Deterministic; ties break
-    by seed."""
-    if not sized_seeds:
-        return []
-    workers = max(1, min(workers, len(sized_seeds)))
-    order = sorted(sized_seeds, key=lambda t: (t[1], t[0]))
-    shards = []
-    for w in range(workers):
-        q = order[w::workers]
-        r = (w * len(q)) // workers
-        shards.append([s for s, _ in q[r:] + q[:r]])
-    return shards
+
+def claim(path: Path) -> bool:
+    """Atomically claim one (root, rung) for this run; False = another
+    worker got it. O_CREAT|O_EXCL on a local fs is the whole protocol."""
+    try:
+        with open(path, "x"):
+            return True
+    except FileExistsError:
+        return False
+
+
+def claims_dir(outdir: Path, rung_idx: int) -> Path:
+    return Path(outdir) / f"rung{rung_idx}_claims"
 
 
 def next_rung(rows_by_rung: dict[int, dict], n_rungs: int) -> int | None:
@@ -330,9 +337,13 @@ def _worker_main(a) -> int:
     recs = _load_evalset(Path(a.evalset))
     oracle = FieldOracle(net_path=a.net, device="cpu")
     out = Path(a.outdir) / f"rung{a.worker_rung}_shard{a.shard}.jsonl"
+    cdir = claims_dir(a.outdir, a.worker_rung)
     seeds = [int(s) for s in a.seeds.split(",")]
+    solved = 0
     with open(out, "a") as fh:
         for seed in seeds:
+            if not claim(cdir / str(seed)):
+                continue
             rec = recs[seed]
             print(f"seed {seed} start "
                   f"(worlds_sigma={rec['n_worlds_sigma']})", flush=True)
@@ -340,9 +351,10 @@ def _worker_main(a) -> int:
                              threads=a.threads or None)
             fh.write(json.dumps(row) + "\n")
             fh.flush()
+            solved += 1
             print(f"seed {seed} {row['verdict']} wall={row['wall_s']}s "
                   f"gap={row.get('final_gap')}", flush=True)
-    print(f"worker done: {len(seeds)} roots -> {out}", flush=True)
+    print(f"worker done: {solved} roots -> {out}", flush=True)
     return 0
 
 
@@ -394,13 +406,10 @@ def _print_plan(recs, ledger, ladder, a) -> None:
             continue
         nw = _rung_workers(a, ladder[r], len(entrants))
         sized = [(s, recs[s]["n_worlds_sigma"]) for s in entrants]
-        print(f"rung {r} shard plan ({len(entrants)} entrants, "
-              f"{nw} workers):")
-        for w, q in enumerate(plan_shards(sized, nw)):
-            sizes = [recs[s]["n_worlds_sigma"] for s in q]
-            print(f"  shard {w}: {len(q)} roots, first->last worlds_sigma "
-                  f"{sizes[0]}->{sizes[-1]}, max {max(sizes)}; "
-                  f"seeds {q[:4]}{'...' if len(q) > 4 else ''}")
+        q = dispatch_order(sized)
+        print(f"rung {r} dispatch queue ({len(entrants)} entrants, "
+              f"{nw} workers, biggest-first by n_worlds_sigma):")
+        print(f"  head {q[:6]}{'...' if len(q) > 6 else ''}")
         break                      # only the next actionable rung is plannable
     print("dry run: no solving.")
 
@@ -497,15 +506,19 @@ def _driver_main(a) -> int:
             continue
         nw = _rung_workers(a, rung, len(entrants))
         sized = [(s, recs[s]["n_worlds_sigma"]) for s in entrants]
-        shards = plan_shards(sized, nw)
+        queue = dispatch_order(sized)
+        cdir = claims_dir(outdir, r)
+        if cdir.exists():
+            shutil.rmtree(cdir)         # claims are per-run; rows are the ledger
+        cdir.mkdir(parents=True)
         print(f"rung {r} [{rung.spec()}]: {len(entrants)} entrants, "
-              f"{len(shards)} workers", flush=True)
+              f"{nw} workers pulling one longest-first queue", flush=True)
         procs = []
-        for w, seeds in enumerate(shards):
+        for w in range(nw):
             log = open(outdir / f"rung{r}_shard{w}.log", "a")
             cmd = [sys.executable, "-u", "-m", "hoyt.refsweep", "--worker",
                    "--worker-rung", str(r), "--shard", str(w),
-                   "--seeds", ",".join(map(str, seeds)),
+                   "--seeds", ",".join(map(str, queue)),
                    "--cap", str(a.cap), "--outdir", str(outdir),
                    "--evalset", str(evalset), "--net", a.net,
                    "--threads", str(a.threads)]

--- a/hoyt/refsweep.py
+++ b/hoyt/refsweep.py
@@ -76,7 +76,8 @@ from pathlib import Path
 
 VERDICT_RANK = {"converged": 0, "gap_capped": 1, "slot_capped": 2, "error": 3}
 USABLE = ("converged", "gap_capped")
-BR_EVERY = 20            # gap-measure cadence (perf-log 18e/18g anchor)
+BR_EVERY = 10            # gap-measure cadence (18o: denser is affordable
+#                          with gap_exit — intermediates price ~1 seat)
 GIB_PER_32M = 7.0        # measured cap-256 worker peak RSS at 32M slots (18g)
 
 
@@ -268,6 +269,7 @@ def solve_root(rec: dict, rung: Rung, rung_idx: int, cap: int,
         ph["walt_br"] = round(time.perf_counter() - t1, 2)
         res = cfr_solve(sub, pay, iters=rung.iters,
                         target_gap=rung.target_gap, br_every=BR_EVERY,
+                        gap_exit=True,
                         wall_budget_s=rung.wall_budget_s,
                         slot_budget=rung.slot_budget)
         # the reference value IS the solve's self-play value (measured

--- a/hoyt/subgame.py
+++ b/hoyt/subgame.py
@@ -233,6 +233,7 @@ def run_engine(sub: Subgame, provider, *, hero=None, worlds=None,
             waves[cw]["sworld"] = sworld.astype(np.int32)
             waves[cw]["counts"] = counts
             waves[cw]["sw"] = sw.astype(np.int32)
+            waves[cw]["actor"] = actor.astype(np.int8)
         if need_path_ids:
             waves[cw]["ph1"], waves[cw]["ph2"] = ph1, ph2
 
@@ -293,6 +294,7 @@ def run_engine(sub: Subgame, provider, *, hero=None, worlds=None,
             swt_sig = np.empty(0, dtype=np.float64)
             sworld_sig = np.empty(0, dtype=np.int64)
             par_sig = tile_sig = counts_sig = np.empty(0, dtype=np.int64)
+            rows = np.empty(0, dtype=np.int64)
             if capture:
                 cap["mv"].append(np.empty(0, dtype=np.int8))
                 cap["dec"].append(None)
@@ -327,6 +329,7 @@ def run_engine(sub: Subgame, provider, *, hero=None, worlds=None,
             sworld_me = np.empty(0, dtype=np.int64)
             par_me = tile_me = np.empty(0, dtype=np.int64)
             child_me_sizes = np.empty(0, dtype=np.int64)
+            gidx = np.empty(0, dtype=np.int64)
 
         # ---- build the child wave (σ children first, then hero's) --------
         parent_c = np.concatenate((par_sig, par_me))
@@ -395,6 +398,12 @@ def run_engine(sub: Subgame, provider, *, hero=None, worlds=None,
                       "tile": tile_c.astype(np.int8),
                       "pseat": pseat_c.astype(np.int8),
                       "hero": None})
+        if keep_slots:
+            # parent-slot index per child slot: resident in the walk (rows
+            # for σ children, gidx for hero's), so consumers never re-derive
+            # it by (node, world) key search (perf-log 18n)
+            waves[-1]["pslot"] = \
+                np.concatenate((rows, gidx)).astype(np.int32)
         leader, led, brank, bseat, tcnt = \
             leader_c, led_c, brank_c, bseat_c, tcnt_c
         ptsvd, mymask = ptsvd_c, mymask_c
@@ -526,14 +535,17 @@ def extract_strategy(waves, choice, best_move, hero_is_me) -> dict:
 
 
 def expand_full_width(sub: Subgame, *, keep_slots=True, need_path_ids=True,
-                      slot_budget=DEFAULT_SLOT_BUDGET) -> dict:
+                      slot_budget=DEFAULT_SLOT_BUDGET,
+                      kernels=False) -> dict:
     """The CFR lane's structural walk: ALL FOUR seats full-width, worlds
     surviving a public action iff the acting hidden seat holds the tile
     (hero=-1: no seat is best-responding; weights flow un-scaled). Returns
     the raw run_engine result with per-wave slot partitions and 128-bit
-    node path ids kept. Memory is the caller's affair — budget-guarded."""
+    node path ids kept. Memory is the caller's affair — budget-guarded.
+    kernels=True selects the numba move-emission fill (buildkernel.py,
+    output-identical; the numpy provider stays the pinned mirror)."""
     from hoyt.profiles import _FullWidthProvider
 
-    return run_engine(sub, _FullWidthProvider(), hero=-1,
+    return run_engine(sub, _FullWidthProvider(kernels=kernels), hero=-1,
                       keep_slots=keep_slots, need_path_ids=need_path_ids,
                       slot_budget=slot_budget)

--- a/hoyt/subgame.py
+++ b/hoyt/subgame.py
@@ -39,6 +39,10 @@ from walt.tables import get_luts, hand_to_mask
 _AR28 = np.arange(28)
 _ALL28 = np.int64((1 << 28) - 1)
 _I64_1 = np.int64(1)
+# per-move clear masks, int32: bits 28-31 stay set after truncation, so
+# 28-bit payloads are unaffected; gathering these avoids the int64
+# promotion an `x &= ~(_I64_1 << mv)` would force on int32 slot arrays
+_NB28_I32 = (~(_I64_1 << np.arange(28))).astype(np.int32)
 
 # 128-bit rolling path hash (two independent 64-bit lanes, wraparound mult).
 _H1_0 = np.uint64(0xCBF29CE484222325)
@@ -84,7 +88,9 @@ class Subgame:
 
         self.root = root
         self.worlds = worlds_u32
-        self.worlds_i64 = worlds_u32.astype(np.int64)
+        # int32, not uint32: the walk's slot arrays are int32 and
+        # uint32/int32 mixing would promote every expression to int64
+        self.worlds_i32 = worlds_u32.astype(np.int32)
         self.weights = weights
         self.total_w = float(weights.sum())
 
@@ -191,13 +197,13 @@ def run_engine(sub: Subgame, provider, *, hero=None, worlds=None,
     bid_team = sub.bid_team
     p0 = sub.p0
 
-    sw = sub.worlds_i64 if worlds is None else \
-        np.asarray(worlds, dtype=np.int64).reshape(-1, 3)
+    sw = sub.worlds_i32 if worlds is None else \
+        np.asarray(worlds, dtype=np.int32).reshape(-1, 3)
     N = int(sw.shape[0])
     swt = (sub.weights if weights is None else
            np.asarray(weights, dtype=np.float64)).copy()
     snode = np.zeros(N, dtype=np.int64)
-    sworld = np.arange(N, dtype=np.int64)
+    sworld = np.arange(N, dtype=np.int32)
     counts = np.array([N], dtype=np.int64)
 
     leader = np.array([sub.leader0], dtype=np.int64)
@@ -237,13 +243,16 @@ def run_engine(sub: Subgame, provider, *, hero=None, worlds=None,
         hmask_nodes = actor == hero
         waves[cw]["hero"] = hmask_nodes
         if keep_slots:
-            # narrowed copies: node ids < slot budget, worlds < N, hands are
-            # 28-bit — int32 halves the resident slot payload; the walk's
-            # working arrays stay int64 (one wave at a time)
+            # node ids < slot budget, worlds < N, hands are 28-bit — int32
+            # halves the resident slot payload. sw/sworld working arrays are
+            # int32 too, so copy=False stores an alias (the walk rebinds
+            # them per wave, never writes in place — sw_sig is a gather
+            # copy); snode stays int64 (index array, and snode<<5 keys
+            # can pass 2^31 near the slot budget), so its store copies
             waves[cw]["snode"] = snode.astype(np.int32)
-            waves[cw]["sworld"] = sworld.astype(np.int32)
+            waves[cw]["sworld"] = sworld.astype(np.int32, copy=False)
             waves[cw]["counts"] = counts
-            waves[cw]["sw"] = sw.astype(np.int32)
+            waves[cw]["sw"] = sw.astype(np.int32, copy=False)
             waves[cw]["actor"] = actor.astype(np.int8)
         if need_path_ids:
             waves[cw]["ph1"], waves[cw]["ph2"] = ph1, ph2
@@ -295,16 +304,16 @@ def run_engine(sub: Subgame, provider, *, hero=None, worlds=None,
             seats_o = actor[snode[rows]]
             cols_o = col_arr[seats_o]
             hid = cols_o >= 0                   # me-as-profile: node-level
-            sw_sig[hid, cols_o[hid]] &= ~(_I64_1 << mv_o[hid])
+            sw_sig[hid, cols_o[hid]] &= _NB28_I32[mv_o[hid]]
             if wmul is None:
                 swt_sig = swt[rows]
             else:
                 swt_sig = (swt[rep] * wmul)[order]
             sworld_sig = sworld[rows]
         else:
-            sw_sig = np.empty((0, 3), dtype=np.int64)
+            sw_sig = np.empty((0, 3), dtype=np.int32)
             swt_sig = np.empty(0, dtype=np.float64)
-            sworld_sig = np.empty(0, dtype=np.int64)
+            sworld_sig = np.empty(0, dtype=np.int32)
             par_sig = tile_sig = counts_sig = np.empty(0, dtype=np.int64)
             rows = np.empty(0, dtype=np.int64)
             if capture:
@@ -337,9 +346,9 @@ def run_engine(sub: Subgame, provider, *, hero=None, worlds=None,
             sworld_me = sworld[gidx]
             child_me_sizes = sizes
         else:
-            sw_me = np.empty((0, 3), dtype=np.int64)
+            sw_me = np.empty((0, 3), dtype=np.int32)
             swt_me = np.empty(0, dtype=np.float64)
-            sworld_me = np.empty(0, dtype=np.int64)
+            sworld_me = np.empty(0, dtype=np.int32)
             par_me = tile_me = np.empty(0, dtype=np.int64)
             child_me_sizes = np.empty(0, dtype=np.int64)
             gidx = np.empty(0, dtype=np.int64)
@@ -438,8 +447,9 @@ def run_engine(sub: Subgame, provider, *, hero=None, worlds=None,
     L = len(waves) - 1
     if keep_slots:
         waves[L]["snode"] = snode.astype(np.int32)
-        waves[L]["sworld"] = sworld.astype(np.int32)
-        waves[L]["counts"], waves[L]["sw"] = counts, sw.astype(np.int32)
+        waves[L]["sworld"] = sworld.astype(np.int32, copy=False)
+        waves[L]["counts"], waves[L]["sw"] = \
+            counts, sw.astype(np.int32, copy=False)
     if need_path_ids:
         waves[L]["ph1"], waves[L]["ph2"] = ph1, ph2
     return {

--- a/hoyt/subgame.py
+++ b/hoyt/subgame.py
@@ -148,6 +148,18 @@ def _empty_wave() -> dict:
     return {"parent": z, "tile": z, "pseat": z, "hero": None}
 
 
+def _cat2(a, b):
+    """concatenate((a, b)) without the full-array copy when either side is
+    empty — the hero=-1 full-width walk concatenates an empty hero side
+    every wave (perf-log 18p). Both inputs are freshly built per wave, so
+    returning one unaliased is safe."""
+    if not len(b):
+        return a
+    if not len(a):
+        return b
+    return np.concatenate((a, b))
+
+
 def run_engine(sub: Subgame, provider, *, hero=None, worlds=None,
                weights=None, heromask0=None, capture=False,
                keep_slots=False, need_path_ids=False, net_state=None,
@@ -224,7 +236,6 @@ def run_engine(sub: Subgame, provider, *, hero=None, worlds=None,
         actor = (leader + pos) % 4
         hmask_nodes = actor == hero
         waves[cw]["hero"] = hmask_nodes
-        starts_node = np.concatenate(([0], np.cumsum(counts)))
         if keep_slots:
             # narrowed copies: node ids < slot budget, worlds < N, hands are
             # 28-bit — int32 halves the resident slot payload; the walk's
@@ -255,9 +266,10 @@ def run_engine(sub: Subgame, provider, *, hero=None, worlds=None,
                 hands = sw[sel, col_arr[seats]]
             else:
                 cols = col_arr[seats]           # -1 where the actor is me
-                hands = np.where(
-                    seats == me, mymask[nsl],
-                    sw[sel, np.where(cols < 0, 0, cols)])
+                hands = sw[sel, np.where(cols < 0, 0, cols)]
+                m_me = seats == me              # minority write beats a
+                if m_me.any():                  # full-width where (18p)
+                    hands[m_me] = mymask[nsl[m_me]]
             rep, mv, wmul, dec = provider.expand(
                 eng, p, pos, sel, nsl, seats, hands)
             if capture:
@@ -302,6 +314,7 @@ def run_engine(sub: Subgame, provider, *, hero=None, worlds=None,
         # ---- hero nodes: branch full-width, replicating slots ------------
         men = np.flatnonzero(hmask_nodes)
         if len(men):
+            starts_node = np.concatenate(([0], np.cumsum(counts)))
             lsm = led[men]
             fb = np.where(lsm >= 0, CFB[lsm], _ALL28)
             hm = heromask[men]
@@ -332,8 +345,8 @@ def run_engine(sub: Subgame, provider, *, hero=None, worlds=None,
             gidx = np.empty(0, dtype=np.int64)
 
         # ---- build the child wave (σ children first, then hero's) --------
-        parent_c = np.concatenate((par_sig, par_me))
-        tile_c = np.concatenate((tile_sig, tile_me))
+        parent_c = _cat2(par_sig, par_me)
+        tile_c = _cat2(tile_sig, tile_me)
         pseat_c = actor[parent_c]
         C = len(parent_c)
         n_nodes += C
@@ -402,22 +415,21 @@ def run_engine(sub: Subgame, provider, *, hero=None, worlds=None,
             # parent-slot index per child slot: resident in the walk (rows
             # for σ children, gidx for hero's), so consumers never re-derive
             # it by (node, world) key search (perf-log 18n)
-            waves[-1]["pslot"] = \
-                np.concatenate((rows, gidx)).astype(np.int32)
+            waves[-1]["pslot"] = _cat2(rows, gidx).astype(np.int32)
         leader, led, brank, bseat, tcnt = \
             leader_c, led_c, brank_c, bseat_c, tcnt_c
         ptsvd, mymask = ptsvd_c, mymask_c
         heromask = mymask if hero_is_me else heromask_c
         if track_net:
             ptsfd, ptsff, played = ptsfd_c, ptsff_c, played_c
-        sw = np.concatenate((sw_sig, sw_me))
-        swt = np.concatenate((swt_sig, swt_me))
-        sworld = np.concatenate((sworld_sig, sworld_me))
-        snode = np.concatenate(
-            (np.repeat(np.arange(len(par_sig)), counts_sig),
-             len(par_sig) + np.repeat(np.arange(len(par_me)),
-                                      child_me_sizes)))
-        counts = np.concatenate((counts_sig, child_me_sizes))
+        sw = _cat2(sw_sig, sw_me)
+        swt = _cat2(swt_sig, swt_me)
+        sworld = _cat2(sworld_sig, sworld_me)
+        snode = _cat2(
+            np.repeat(np.arange(len(par_sig)), counts_sig),
+            len(par_sig) + np.repeat(np.arange(len(par_me)),
+                                     child_me_sizes))
+        counts = _cat2(counts_sig, child_me_sizes)
         if sw.shape[0] > slot_budget:
             raise KernelMemoryError(
                 f"wave p={p + 1} holds {sw.shape[0]} slots > budget "

--- a/hoyt/tests/test_cfr_parity.py
+++ b/hoyt/tests/test_cfr_parity.py
@@ -23,6 +23,10 @@ Gates:
                       updates, #82) == engine="loop" on the same toys and
                       pins, fp64. The fused engine is designed bitwise-equal
                       to "wave"; this gate pins it to the verified loop.
+  P4 pricing oracle — the wave/fused engines' in-struct gap pricing
+                      (_wave_br, perf-log 18m) == recomputing the gap on
+                      the exported profile with ref.br_solve, <= 1e-9, on
+                      toys and pins. br_solve stays the standing oracle.
 """
 from __future__ import annotations
 
@@ -140,10 +144,48 @@ def gate_P3() -> None:
           "; ".join(bad) if bad else " ".join(lines))
 
 
+def gate_P4() -> None:
+    from hoyt.reference import sign_of
+    bad = []
+    lines = []
+    cases = [(name, None) for name in
+             ("t2_decl_w3", "t2_def_w3", "t2_decl_w12", "t2_def_w12")]
+    for name in ("t2_decl_w3", "t2_def_w12"):
+        cases.append((name, "pin"))
+    for name, mode in cases:
+        toy = T.get_toy(name)
+        sub = toy.build()
+        kw = dict(iters=60, br_every=20, impl=ref)
+        pinned = {}
+        if mode == "pin":
+            u, v = sub.me, (sub.me + 1) % 4
+            others = [s for s in range(4) if s not in (u, v)]
+            sigma = T.lowest_legal_sigma(sub, others)
+            pinned = {s: sigma for s in others}
+            kw.update(iters=80, pinned=pinned)
+        res = cfr_solve(sub, PAY, engine="fused", **kw)
+        bid_team = int(sub.root.bidder) % 2
+        live = [s for s in range(4) if s not in pinned]
+        gap_ref = 0.0
+        for s in live:
+            bru = ref.br_solve(sub, res.profile, PAY, hero=s,
+                               want_strategy=False).value
+            gap_ref = max(gap_ref, sign_of(s, bid_team) * (bru - res.value))
+        d = abs(res.gap - gap_ref)
+        tag = f"{name}{'+pin' if mode else ''}"
+        lines.append(f"{tag}:{d:.1e}")
+        if d > TOL:
+            bad.append(f"{tag}: in-struct gap {res.gap} vs br_solve "
+                       f"{gap_ref} (|d|={d:.2e})")
+    _gate(not bad, "P4 in-struct pricing == ref.br_solve oracle (<=1e-9)",
+          "; ".join(bad) if bad else " ".join(lines))
+
+
 def main() -> int:
     gate_P1()
     gate_P2()
     gate_P3()
+    gate_P4()
     if _failures:
         print(f"\n{len(_failures)} gate(s) FAILED: {_failures}")
         return 1

--- a/hoyt/tests/test_cfr_parity.py
+++ b/hoyt/tests/test_cfr_parity.py
@@ -19,6 +19,10 @@ Gates:
   P2 pinned parity  — same, under the 2p-izable pin (the wave tree contains
                       pinned zero-probability subtrees the loop tree prunes;
                       reach-gated export must make the domains identical).
+  P3 fused parity   — engine="fused" (numba kernels + forced-slot-compressed
+                      updates, #82) == engine="loop" on the same toys and
+                      pins, fp64. The fused engine is designed bitwise-equal
+                      to "wave"; this gate pins it to the verified loop.
 """
 from __future__ import annotations
 
@@ -109,9 +113,37 @@ def gate_P2() -> None:
           "; ".join(bad) if bad else " ".join(lines))
 
 
+def gate_P3() -> None:
+    bad = []
+    lines = []
+    for name in ("t2_decl_w3", "t2_def_w3", "t2_decl_w12", "t2_def_w12"):
+        toy = T.get_toy(name)
+        sub = toy.build()
+        kw = dict(iters=60, br_every=20, impl=ref)
+        res_l = cfr_solve(sub, PAY, engine="loop", **kw)
+        res_f = cfr_solve(sub, PAY, engine="fused", **kw)
+        d = _compare(name, res_l, res_f, bad)
+        lines.append(f"{name}:{d:.1e}")
+    for name in ("t2_decl_w3", "t2_def_w12"):
+        toy = T.get_toy(name)
+        sub = toy.build()
+        u, v = sub.me, (sub.me + 1) % 4
+        others = [s for s in range(4) if s not in (u, v)]
+        sigma = T.lowest_legal_sigma(sub, others)
+        pinned = {s: sigma for s in others}
+        kw = dict(iters=80, br_every=20, impl=ref, pinned=pinned)
+        res_l = cfr_solve(sub, PAY, engine="loop", **kw)
+        res_f = cfr_solve(sub, PAY, engine="fused", **kw)
+        d = _compare(f"{name}+pin", res_l, res_f, bad)
+        lines.append(f"{name}+pin:{d:.1e}")
+    _gate(not bad, "P3 fused == loop (4-seat toys + 2p-izable pins)",
+          "; ".join(bad) if bad else " ".join(lines))
+
+
 def main() -> int:
     gate_P1()
     gate_P2()
+    gate_P3()
     if _failures:
         print(f"\n{len(_failures)} gate(s) FAILED: {_failures}")
         return 1

--- a/hoyt/tests/test_cfr_parity.py
+++ b/hoyt/tests/test_cfr_parity.py
@@ -27,6 +27,10 @@ Gates:
                       (_wave_br, perf-log 18m) == recomputing the gap on
                       the exported profile with ref.br_solve, <= 1e-9, on
                       toys and pins. br_solve stays the standing oracle.
+  P5 gap_exit       — partial intermediate pricing (perf-log 18o) leaves
+                      the stop iteration and the final gap/value/profile
+                      exactly unchanged; intermediate partial gaps are
+                      certified > target and <= the full max.
 """
 from __future__ import annotations
 
@@ -181,11 +185,61 @@ def gate_P4() -> None:
           "; ".join(bad) if bad else " ".join(lines))
 
 
+def gate_P5() -> None:
+    # gap_exit invariance (perf-log 18o): partial intermediate pricing must
+    # not move the stop iteration or the final result — final gap/value/
+    # profile identical (exact equality), trace iterations identical, and
+    # every intermediate partial gap <= the full measurement's (it is a
+    # max over a prefix of seats) while still certifying > target.
+    bad = []
+    lines = []
+    n_intermediate = 0
+    for name in ("t2_decl_w3", "t2_def_w3", "t2_decl_w12", "t2_def_w12"):
+        toy = T.get_toy(name)
+        sub = toy.build()
+        # 0.0005 forces 6-9 above-target intermediate measurements on the
+        # w12 toys, so the partial-exit path is genuinely exercised
+        kw = dict(iters=60, br_every=5, target_gap=0.0005, impl=ref)
+        res_f = cfr_solve(sub, PAY, engine="fused", **kw)
+        res_x = cfr_solve(sub, PAY, engine="fused", gap_exit=True, **kw)
+        n_intermediate += len(res_x.trace) - 1
+        if res_x.iters_run != res_f.iters_run:
+            bad.append(f"{name}: stop iter {res_x.iters_run} vs "
+                       f"{res_f.iters_run}")
+            continue
+        if res_x.gap != res_f.gap or res_x.value != res_f.value:
+            bad.append(f"{name}: final gap/value differ "
+                       f"({res_x.gap} vs {res_f.gap})")
+        if [i for i, _ in res_x.trace] != [i for i, _ in res_f.trace]:
+            bad.append(f"{name}: trace iters differ")
+            continue
+        for (i, gx), (_, gf) in zip(res_x.trace[:-1], res_f.trace[:-1]):
+            if gx > gf + 1e-15 or gx <= kw["target_gap"]:
+                bad.append(f"{name}: partial gap {gx} vs full {gf} at {i}")
+        if res_x.trace[-1][1] != res_f.trace[-1][1]:
+            bad.append(f"{name}: stopping gap differs")
+        ex, ef = res_x.profile.entries, res_f.profile.entries
+        if set(ex) != set(ef) or any(
+                ex[k][0] != ef[k][0]
+                or (len(ex[k][1]) and float(np.max(np.abs(
+                    np.asarray(ex[k][1]) - np.asarray(ef[k][1])))) != 0.0)
+                for k in ex):
+            bad.append(f"{name}: profiles differ")
+        lines.append(f"{name}:it{res_x.iters_run}")
+    if n_intermediate < 4:
+        bad.append(f"only {n_intermediate} intermediate measurements — "
+                   "the exit path was not exercised")
+    _gate(not bad, "P5 gap_exit invariance (stop iter + final result exact)",
+          "; ".join(bad) if bad else
+          " ".join(lines) + f" ({n_intermediate} intermediates)")
+
+
 def main() -> int:
     gate_P1()
     gate_P2()
     gate_P3()
     gate_P4()
+    gate_P5()
     if _failures:
         print(f"\n{len(_failures)} gate(s) FAILED: {_failures}")
         return 1

--- a/hoyt/tests/test_cfr_parity.py
+++ b/hoyt/tests/test_cfr_parity.py
@@ -234,12 +234,42 @@ def gate_P5() -> None:
           " ".join(lines) + f" ({n_intermediate} intermediates)")
 
 
+def gate_P13() -> None:
+    # threaded fused == sequential fused, exactly (perf-log P13): every
+    # parallel fold owns a disjoint output range with unchanged
+    # within-range accumulation order, so thread count must not move a bit.
+    # threads=3 forces uneven chunking; gap_exit composes with threading.
+    bad = []
+    lines = []
+    for name in ("t2_decl_w3", "t2_def_w3", "t2_decl_w12", "t2_def_w12"):
+        toy = T.get_toy(name)
+        sub = toy.build()
+        kw = dict(iters=60, br_every=20, impl=ref)
+        res_s = cfr_solve(sub, PAY, engine="fused", **kw)
+        for th in (3, 4):
+            res_t = cfr_solve(sub, PAY, engine="fused", threads=th, **kw)
+            d = _compare(f"{name}@th{th}", res_s, res_t, bad)
+            if d != 0.0:
+                bad.append(f"{name}@th{th}: max |d| {d:.2e} != 0")
+        kx = dict(iters=60, br_every=5, target_gap=0.0005, impl=ref)
+        res_x = cfr_solve(sub, PAY, engine="fused", gap_exit=True, **kx)
+        res_xt = cfr_solve(sub, PAY, engine="fused", gap_exit=True,
+                           threads=4, **kx)
+        dx = _compare(f"{name}+exit@th4", res_x, res_xt, bad)
+        if dx != 0.0 or res_x.trace != res_xt.trace:
+            bad.append(f"{name}+exit@th4: not exact (|d| {dx:.2e})")
+        lines.append(name)
+    _gate(not bad, "P13 threaded fused == sequential fused (bitwise)",
+          "; ".join(bad) if bad else " ".join(lines))
+
+
 def main() -> int:
     gate_P1()
     gate_P2()
     gate_P3()
     gate_P4()
     gate_P5()
+    gate_P13()
     if _failures:
         print(f"\n{len(_failures)} gate(s) FAILED: {_failures}")
         return 1

--- a/hoyt/tests/test_refsweep.py
+++ b/hoyt/tests/test_refsweep.py
@@ -2,8 +2,8 @@
 
 Two halves, both toy-fast (no nets, no big roots):
 
-- Pure ladder logic (parse/shard/resume/merge) — the functions refsweep's
-  driver runs, tested without solving anything.
+- Pure ladder logic (parse/dispatch/claim/resume/merge) — the functions
+  refsweep's driver runs, tested without solving anything.
 - cfr_solve wall_budget_s semantics on toys, impl=hoyt.reference: a capped
   stop is a QUANTIFIED verdict (capped=True, gap present and exactly equal
   to an uncapped run stopped at the same iteration — the solver is
@@ -24,10 +24,11 @@ from hoyt.refsweep import (
     DEFAULT_RUNGS,
     Rung,
     best_row,
+    claim,
+    dispatch_order,
     load_ledger,
     next_rung,
     parse_rungs,
-    plan_shards,
 )
 
 PAY = T.payoff_points()
@@ -49,35 +50,26 @@ def test_parse_rungs_rejects_malformed():
         parse_rungs("")
 
 
-def test_plan_shards_exact_partition():
+def test_dispatch_order_longest_first_by_size():
     sized = [(1000 + i, (i * 37) % 400) for i in range(17)]
-    shards = plan_shards(sized, 4)
-    assert len(shards) == 4
-    flat = [s for q in shards for s in q]
-    assert sorted(flat) == sorted(s for s, _ in sized)
-    assert len(set(flat)) == len(sized)
-    # deterministic
-    assert plan_shards(sized, 4) == shards
+    q = dispatch_order(sized)
+    assert sorted(q) == sorted(s for s, _ in sized)
+    sizes = dict(sized)
+    assert [sizes[s] for s in q] == sorted(
+        (z for _, z in sized), reverse=True)
+    assert dispatch_order(sized) == q                  # deterministic
+    assert dispatch_order([]) == []
 
 
-def test_plan_shards_more_workers_than_seeds():
-    sized = [(1, 10), (2, 20)]
-    shards = plan_shards(sized, 8)
-    assert len(shards) == 2
-    assert sorted(s for q in shards for s in q) == [1, 2]
-    assert plan_shards([], 8) == []
+def test_dispatch_order_ties_break_by_seed():
+    assert dispatch_order([(5, 7), (3, 7), (4, 9)]) == [4, 3, 5]
 
 
-def test_plan_shards_staggers_monster_phases():
-    # 40 roots, sizes ascending with seed; 4 workers. Each queue must span
-    # the size range, and the position of each queue's largest root must
-    # NOT be rank-aligned across queues (the snake's sin).
-    sized = [(i, i) for i in range(40)]
-    shards = plan_shards(sized, 4)
-    monster_pos = [q.index(max(q)) for q in shards]
-    assert len(set(monster_pos)) > 1
-    for q in shards:
-        assert max(q) >= 36 and min(q) <= 3     # spans the range
+def test_claim_is_exclusive(tmp_path):
+    p = tmp_path / "555000"
+    assert claim(p) is True
+    assert claim(p) is False                # second claimant loses
+    assert claim(tmp_path / "555001") is True
 
 
 def test_next_rung_ladder():

--- a/hoyt/tests/test_toys.py
+++ b/hoyt/tests/test_toys.py
@@ -500,6 +500,34 @@ def test_full_width_walk():
         assert got.tolist() == ref_counts
         for w in res["waves"][:-1]:
             assert "snode" in w and "ph1" in w
+
+        # resident pslot/actor (perf-log 18n): pslot must map every child
+        # slot to the parent slot with the same (node, world) key, and
+        # actor must equal the seat of each node's first child edge
+        waves = res["waves"]
+        N = worlds.shape[0]
+        for j in range(len(waves) - 1):
+            wj, wn = waves[j], waves[j + 1]
+            parn = wn["parent"]
+            kp = wj["snode"].astype(np.int64) * N \
+                + wj["sworld"].astype(np.int64)
+            kc = parn[wn["snode"]].astype(np.int64) * N \
+                + wn["sworld"].astype(np.int64)
+            assert np.array_equal(kp[wn["pslot"]], kc)
+            firstchild = np.searchsorted(parn, np.arange(len(wj["counts"])))
+            assert np.array_equal(
+                wj["actor"], wn["pseat"][firstchild])
+
+        # the numba fill walk (fused lane) must equal the numpy mirror
+        res_k = expand_full_width(sub, kernels=True)
+        assert res_k["n_nodes"] == res["n_nodes"]
+        for k in ("snode", "swt", "sworld", "ptsvd"):
+            assert np.array_equal(res_k["leaf"][k], leaf[k])
+        for a, b in zip(res["waves"], res_k["waves"]):
+            for k in ("parent", "tile", "pseat", "hero", "snode", "sworld",
+                      "counts", "sw", "pslot", "actor", "ph1", "ph2"):
+                if k in a or k in b:
+                    assert np.array_equal(a[k], b[k]), k
         done += 1
     assert done >= 6, f"only {done} toys actually checked"
 

--- a/wiki/entities/hoyt.md
+++ b/wiki/entities/hoyt.md
@@ -2,7 +2,7 @@
 title: hoyt — the game's own referee
 kind: entity
 first_seen: 2026-07-18
-last_updated: 2026-07-18
+last_updated: 2026-07-19
 status: active
 ---
 
@@ -76,10 +76,10 @@ info set in about the cost of one ordinary solve — after which:
 | H4 BR re-solve after compile | p50 0.9 ms (45× net wavefront) |
 | H5-cap512 BR | p50 3.5 ms; compile 0.35 s |
 | CFR gap ≤0.05 pts | ≤40 iterations at EVERY root tried — **scale-invariant in worlds** (10 → 33,740) |
-| CFR wall/root, cap-256 | anchor **12.6 s** after the fused iterate + in-struct gap pricing + resident build + walk elisions ([[perf-log]] 18l–p: iterate 7.1×, br 16×, build 2.7×; was 88.6 s at the start of 2026-07-18, ~115 s before that); iterate is the top bucket (45% fleet-level), parallel-iterate (P13) registered |
+| CFR wall/root, cap-256 | anchor **7.2 s** after the fused iterate + in-struct gap pricing + resident build + walk elisions + threaded iterate ([[perf-log]] 18l–19a: iterate 7.1× then 2.67–3.12× more at 4–8 threads (bitwise at any count — P13's disjoint-output structure), br 16×, build 2.7×; was 88.6 s at the start of 2026-07-18, ~115 s before that); build is the top bucket now (48% fleet-level at threads=4) |
 | stochastic-field tree blowup | p50 526×, max 5219× vs deterministic σ (measured, was argued ×10²–10⁴) |
 | jud rent, ALL 200 evalset roots | median **+1.53 pts/root** (mean +2.02, p90 +5.22, range **−8.65…+15.49**; the 12-root "never negative" died — 18 roots < −0.5, the population term cuts both ways) |
-| refsweep cascade velocity | rung-0 **224 evals/hour** pre-kernel; post 18l–o: same-seed paired sample **18.9× less worker-time per usable eval**, 19/20 converge at rung 0 and the 555090 wedge now cashes at rung 2 (578 s ladder; banked: 1,799 s) → **~2,700–3,700/hour projected** ([[perf-log]] 18o); deepening 87% → 99% → 100% over three rungs pre-kernel |
+| refsweep cascade velocity | rung-0 **224 evals/hour** pre-kernel; post 18l–19a (threads=4 default): same-seed paired sample **23.7× less worker-time per usable eval** (11.7 worker-s), 19/20 converge at rung 0 and the 555090 wedge now cashes at rung 2 (473 s full-cascade root-wall; banked: 1,799 s) → **~3,400–4,650/hour projected** ([[perf-log]] 19a); deepening 87% → 99% → 100% over three rungs pre-kernel |
 | mixing | ~500 toy configurations, zero mixed equilibria — vs deterministic fields, late 42 is **pure**; mixing must earn via concealment, not value |
 
 Habitat: **H ≤ 4 comfortable** (H3 nearly free); H5 needs the queued

--- a/wiki/entities/hoyt.md
+++ b/wiki/entities/hoyt.md
@@ -56,8 +56,11 @@ info set in about the cost of one ordinary solve — after which:
   [[perf-log]] 18l), "wave" (the pure-numpy mirror), "loop" (the
   verified recursive oracle). Forced info sets (~83% at H4) are exactly
   inert in RM+ (σ ≡ 1.0, regret ≡ 0), so compressing them out is a
-  bitwise no-op. Verified on toys against scipy-LP / full-strategy
-  enumeration.
+  bitwise no-op. Gap pricing is IN-STRUCT ([[perf-log]] 18m): exact BR
+  as a forward-reach + backward-argmax pass over the resident wave
+  structure — no per-measurement export or re-walk; br_solve stays the
+  pricing oracle via the loop engine and gate P4 (≤1e-9). Verified on
+  toys against scipy-LP / full-strategy enumeration.
 - **Exploitability meter**: BR gain vs any frozen profile — counter-walt
   ([#77](https://github.com/jasonyandell/mk5-main/issues/77)) is this
   meter pointed at walt.
@@ -69,10 +72,10 @@ info set in about the cost of one ordinary solve — after which:
 | H4 BR re-solve after compile | p50 0.9 ms (45× net wavefront) |
 | H5-cap512 BR | p50 3.5 ms; compile 0.35 s |
 | CFR gap ≤0.05 pts | ≤40 iterations at EVERY root tried — **scale-invariant in worlds** (10 → 33,740) |
-| CFR wall/root, cap-256 | anchor 41 s after the fused iterate ([[perf-log]] 18l: iterate 7.1×, solve wall ~2×; was ~92 s post-18g, ~115 s before); gap pricing now 65–71% of wall |
+| CFR wall/root, cap-256 | anchor **15.9 s** after the fused iterate + in-struct gap pricing ([[perf-log]] 18l+18m: iterate 7.1×, br 16×; was 88.6 s at the start of 2026-07-18, ~115 s before that); build is now the top bucket (43%) |
 | stochastic-field tree blowup | p50 526×, max 5219× vs deterministic σ (measured, was argued ×10²–10⁴) |
 | jud rent, ALL 200 evalset roots | median **+1.53 pts/root** (mean +2.02, p90 +5.22, range **−8.65…+15.49**; the 12-root "never negative" died — 18 roots < −0.5, the population term cuts both ways) |
-| refsweep cascade velocity | rung-0 **224 evals/hour** pre-kernel (5 workers, 90 s cap); post-fused-iterate: same-seed paired sample **3.59× less worker-time** → **~800/hour projected** ([[perf-log]] 18l); deepening 87% → 99% → 100% over three rungs |
+| refsweep cascade velocity | rung-0 **224 evals/hour** pre-kernel; post 18l+18m: same-seed paired sample **14.2× less worker-time per usable eval**, 19/20 converge at rung 0 (two roots no longer ladder) → **~2,000–2,800/hour projected** ([[perf-log]] 18m); deepening 87% → 99% → 100% over three rungs pre-kernel |
 | mixing | ~500 toy configurations, zero mixed equilibria — vs deterministic fields, late 42 is **pure**; mixing must earn via concealment, not value |
 
 Habitat: **H ≤ 4 comfortable** (H3 nearly free); H5 needs the queued

--- a/wiki/entities/hoyt.md
+++ b/wiki/entities/hoyt.md
@@ -79,7 +79,7 @@ info set in about the cost of one ordinary solve — after which:
 | CFR wall/root, cap-256 | anchor **13.0 s** after the fused iterate + in-struct gap pricing + resident build ([[perf-log]] 18l+18m+18n: iterate 7.1×, br 16×, build 2.36×; was 88.6 s at the start of 2026-07-18, ~115 s before that); iterate is back on top (50% fleet-level) |
 | stochastic-field tree blowup | p50 526×, max 5219× vs deterministic σ (measured, was argued ×10²–10⁴) |
 | jud rent, ALL 200 evalset roots | median **+1.53 pts/root** (mean +2.02, p90 +5.22, range **−8.65…+15.49**; the 12-root "never negative" died — 18 roots < −0.5, the population term cuts both ways) |
-| refsweep cascade velocity | rung-0 **224 evals/hour** pre-kernel; post 18l+18m+18n: same-seed paired sample **16.9× less worker-time per usable eval**, 19/20 converge at rung 0 and the 555090 wedge now cashes at rung 2 in 366 s (banked: 1,799 s) → **~2,400–3,300/hour projected** ([[perf-log]] 18n); deepening 87% → 99% → 100% over three rungs pre-kernel |
+| refsweep cascade velocity | rung-0 **224 evals/hour** pre-kernel; post 18l–o: same-seed paired sample **18.9× less worker-time per usable eval**, 19/20 converge at rung 0 and the 555090 wedge now cashes at rung 2 (578 s ladder; banked: 1,799 s) → **~2,700–3,700/hour projected** ([[perf-log]] 18o); deepening 87% → 99% → 100% over three rungs pre-kernel |
 | mixing | ~500 toy configurations, zero mixed equilibria — vs deterministic fields, late 42 is **pure**; mixing must earn via concealment, not value |
 
 Habitat: **H ≤ 4 comfortable** (H3 nearly free); H5 needs the queued

--- a/wiki/entities/hoyt.md
+++ b/wiki/entities/hoyt.md
@@ -76,7 +76,7 @@ info set in about the cost of one ordinary solve — after which:
 | H4 BR re-solve after compile | p50 0.9 ms (45× net wavefront) |
 | H5-cap512 BR | p50 3.5 ms; compile 0.35 s |
 | CFR gap ≤0.05 pts | ≤40 iterations at EVERY root tried — **scale-invariant in worlds** (10 → 33,740) |
-| CFR wall/root, cap-256 | anchor **13.0 s** after the fused iterate + in-struct gap pricing + resident build ([[perf-log]] 18l+18m+18n: iterate 7.1×, br 16×, build 2.36×; was 88.6 s at the start of 2026-07-18, ~115 s before that); iterate is back on top (50% fleet-level) |
+| CFR wall/root, cap-256 | anchor **12.6 s** after the fused iterate + in-struct gap pricing + resident build + walk elisions ([[perf-log]] 18l–p: iterate 7.1×, br 16×, build 2.7×; was 88.6 s at the start of 2026-07-18, ~115 s before that); iterate is the top bucket (45% fleet-level), parallel-iterate (P13) registered |
 | stochastic-field tree blowup | p50 526×, max 5219× vs deterministic σ (measured, was argued ×10²–10⁴) |
 | jud rent, ALL 200 evalset roots | median **+1.53 pts/root** (mean +2.02, p90 +5.22, range **−8.65…+15.49**; the 12-root "never negative" died — 18 roots < −0.5, the population term cuts both ways) |
 | refsweep cascade velocity | rung-0 **224 evals/hour** pre-kernel; post 18l–o: same-seed paired sample **18.9× less worker-time per usable eval**, 19/20 converge at rung 0 and the 555090 wedge now cashes at rung 2 (578 s ladder; banked: 1,799 s) → **~2,700–3,700/hour projected** ([[perf-log]] 18o); deepening 87% → 99% → 100% over three rungs pre-kernel |

--- a/wiki/entities/hoyt.md
+++ b/wiki/entities/hoyt.md
@@ -59,7 +59,11 @@ info set in about the cost of one ordinary solve — after which:
   bitwise no-op. Gap pricing is IN-STRUCT ([[perf-log]] 18m): exact BR
   as a forward-reach + backward-argmax pass over the resident wave
   structure — no per-measurement export or re-walk; br_solve stays the
-  pricing oracle via the loop engine and gate P4 (≤1e-9). Verified on
+  pricing oracle via the loop engine and gate P4 (≤1e-9). The build
+  keeps the walk's parent-slot/actor arrays resident instead of
+  re-deriving them by key search, and the fused lane emits legal moves
+  via `buildkernel.py` ([[perf-log]] 18n, output-identical; the numpy
+  provider is the pinned mirror). Verified on
   toys against scipy-LP / full-strategy enumeration.
 - **Exploitability meter**: BR gain vs any frozen profile — counter-walt
   ([#77](https://github.com/jasonyandell/mk5-main/issues/77)) is this
@@ -72,10 +76,10 @@ info set in about the cost of one ordinary solve — after which:
 | H4 BR re-solve after compile | p50 0.9 ms (45× net wavefront) |
 | H5-cap512 BR | p50 3.5 ms; compile 0.35 s |
 | CFR gap ≤0.05 pts | ≤40 iterations at EVERY root tried — **scale-invariant in worlds** (10 → 33,740) |
-| CFR wall/root, cap-256 | anchor **15.9 s** after the fused iterate + in-struct gap pricing ([[perf-log]] 18l+18m: iterate 7.1×, br 16×; was 88.6 s at the start of 2026-07-18, ~115 s before that); build is now the top bucket (43%) |
+| CFR wall/root, cap-256 | anchor **13.0 s** after the fused iterate + in-struct gap pricing + resident build ([[perf-log]] 18l+18m+18n: iterate 7.1×, br 16×, build 2.36×; was 88.6 s at the start of 2026-07-18, ~115 s before that); iterate is back on top (50% fleet-level) |
 | stochastic-field tree blowup | p50 526×, max 5219× vs deterministic σ (measured, was argued ×10²–10⁴) |
 | jud rent, ALL 200 evalset roots | median **+1.53 pts/root** (mean +2.02, p90 +5.22, range **−8.65…+15.49**; the 12-root "never negative" died — 18 roots < −0.5, the population term cuts both ways) |
-| refsweep cascade velocity | rung-0 **224 evals/hour** pre-kernel; post 18l+18m: same-seed paired sample **14.2× less worker-time per usable eval**, 19/20 converge at rung 0 (two roots no longer ladder) → **~2,000–2,800/hour projected** ([[perf-log]] 18m); deepening 87% → 99% → 100% over three rungs pre-kernel |
+| refsweep cascade velocity | rung-0 **224 evals/hour** pre-kernel; post 18l+18m+18n: same-seed paired sample **16.9× less worker-time per usable eval**, 19/20 converge at rung 0 and the 555090 wedge now cashes at rung 2 in 366 s (banked: 1,799 s) → **~2,400–3,300/hour projected** ([[perf-log]] 18n); deepening 87% → 99% → 100% over three rungs pre-kernel |
 | mixing | ~500 toy configurations, zero mixed equilibria — vs deterministic fields, late 42 is **pure**; mixing must earn via concealment, not value |
 
 Habitat: **H ≤ 4 comfortable** (H3 nearly free); H5 needs the queued

--- a/wiki/entities/hoyt.md
+++ b/wiki/entities/hoyt.md
@@ -50,10 +50,14 @@ info set in about the cost of one ordinary solve — after which:
   compile to one shape.
 - **CFR+ references** (`cfr_solve`): regret-matching+, alternating
   updates, linear averaging, over all four seats; gap = max single-seat
-  exact-BR gain vs the average, priced by `br_solve`. Two engines,
-  bitwise-pinned (the verified slow loop is kept as the parity oracle for
-  the vectorized wave engine). Verified on toys against scipy-LP /
-  full-strategy enumeration.
+  exact-BR gain vs the average, priced by `br_solve`. Three engines,
+  bitwise-pinned: "fused" (default — numba edge kernels over int32
+  indices with the forced-slot-compressed strategy space, #82,
+  [[perf-log]] 18l), "wave" (the pure-numpy mirror), "loop" (the
+  verified recursive oracle). Forced info sets (~83% at H4) are exactly
+  inert in RM+ (σ ≡ 1.0, regret ≡ 0), so compressing them out is a
+  bitwise no-op. Verified on toys against scipy-LP / full-strategy
+  enumeration.
 - **Exploitability meter**: BR gain vs any frozen profile — counter-walt
   ([#77](https://github.com/jasonyandell/mk5-main/issues/77)) is this
   meter pointed at walt.
@@ -65,10 +69,10 @@ info set in about the cost of one ordinary solve — after which:
 | H4 BR re-solve after compile | p50 0.9 ms (45× net wavefront) |
 | H5-cap512 BR | p50 3.5 ms; compile 0.35 s |
 | CFR gap ≤0.05 pts | ≤40 iterations at EVERY root tried — **scale-invariant in worlds** (10 → 33,740) |
-| CFR wall/root, cap-256 | median ~92 s, peak RSS 6.7 GiB after the columnar-profile perf day ([[perf-log]] 18g; was ~115 s / 7.4+ GiB) |
+| CFR wall/root, cap-256 | anchor 41 s after the fused iterate ([[perf-log]] 18l: iterate 7.1×, solve wall ~2×; was ~92 s post-18g, ~115 s before); gap pricing now 65–71% of wall |
 | stochastic-field tree blowup | p50 526×, max 5219× vs deterministic σ (measured, was argued ×10²–10⁴) |
 | jud rent, ALL 200 evalset roots | median **+1.53 pts/root** (mean +2.02, p90 +5.22, range **−8.65…+15.49**; the 12-root "never negative" died — 18 roots < −0.5, the population term cuts both ways) |
-| refsweep cascade velocity | rung-0 **224 evals/hour** (5 workers, 90 s cap); explore-mode 30 s cap ≈ 750/hour within ~0.1 pt; deepening 87% → 99% → 100% over three rungs |
+| refsweep cascade velocity | rung-0 **224 evals/hour** pre-kernel (5 workers, 90 s cap); post-fused-iterate: same-seed paired sample **3.59× less worker-time** → **~800/hour projected** ([[perf-log]] 18l); deepening 87% → 99% → 100% over three rungs |
 | mixing | ~500 toy configurations, zero mixed equilibria — vs deterministic fields, late 42 is **pure**; mixing must earn via concealment, not value |
 
 Habitat: **H ≤ 4 comfortable** (H3 nearly free); H5 needs the queued

--- a/wiki/index-topics.md
+++ b/wiki/index-topics.md
@@ -40,6 +40,7 @@ Concepts, methods, and synthesized findings.
 - [[topics/eval-matrix-bradley-terry|eval-matrix-bradley-terry]] — Bradley-Terry Elo tournament infra over named players (zeb checkpoints, random, heuristic, eq:n=10/50/100/500) (complete)
 - [[topics/expected-q-value|expected-q-value]] — E[Q]: scalar measuring position value, supplied by forge's Q-value checkpoint (active)
 - [[topics/game-context-qa|game-context-qa]] — 5-type game-context Q&A from real game records, ~170 tok prompts; expanded to 14 categories in v9 (superseded)
+- [[topics/hoyt-perf-primer|hoyt-perf-primer]] — plain-language decoder for the hoyt perf campaign: H4/anchor/worlds/cap/gap/rent/banked/rungs/wedge/pull-queue defined in birth order, runtime characteristics milestone by milestone (18.5 → 727 evals/hr), and the structural fork (active)
 - [[topics/huggingface-assets|huggingface-assets]] — account-verified catalog of every HF repo the project generated (4 datasets incl. mk5-run-evidence, ~95 model repos, plus referenced-but-absent names); the off-git shelf run-artifacts-policy points at (active)
 - [[topics/ideated-not-built|ideated-not-built]] — Era 5's unbuilt record: ~15 conversations designed a whole generation named but never shipped (Harl / LLem / walker / …) — classified IDEATED, never claimed as artifacts (complete)
 - [[topics/intermediate-ai|intermediate-ai]] — the shipped pre-ML opponent: PIMC world sampling + constraint tracking + partnership minimax (active)

--- a/wiki/topics/hoyt-perf-primer.md
+++ b/wiki/topics/hoyt-perf-primer.md
@@ -1,0 +1,140 @@
+---
+title: hoyt perf primer — the shorthand decoded, start to current
+kind: topic
+first_seen: 2026-07-19
+last_updated: 2026-07-19
+status: active
+---
+
+Plain-language decoder for the [[hoyt]] perf campaign's vocabulary, with
+the runtime characteristics at each milestone. Written because the
+lineage ([[perf-log]] 18a–19i) developed dense shorthand that resists
+cold reading. Receipts live in [[perf-log]]; laws live in [[perf]]; this
+page only translates. If a term here drifts from the log, the log wins.
+
+## The objective, in game units
+
+A [[texas-42]] hand has 7 tricks. **H4 = horizon 4 = positions where
+every player holds exactly 4 dominoes** (the last 4 tricks). Each
+additional trick of horizon multiplies the tree ~100× ([[walt-spec]]).
+Jason's directive (perf-log 18h): optimize **4th-play evals per
+wall-clock hour** — how many 4-tricks-left positions get exactly solved
+per hour. **One eval** = one root taken to a CFR+ reference strategy
+*plus its certificate*.
+
+## Glossary, in birth order
+
+- **root** — one frozen H4 position (turn, play history, hero's tiles,
+  score).
+- **the anchor** — `hoyt/evalset_h4_v1.jsonl`: 200 stratified roots,
+  frozen forever, so numbers stay comparable across years. The log also
+  uses "the anchor solve" for the single paired-bench root 555006 — two
+  senses, same word.
+- **worlds** — consistent deals of the three hidden hands (10 to
+  ~34,000 per root). **σ-consistent**: filtered to deals where the
+  net's decisions match the actual play. **σ** is a strategy; the net's
+  is captured once per root by `compile_sigma` (≈ one net solve), after
+  which everything is net-free.
+- **cap 256** — solve over ≤256 sampled worlds. Priced: cap 512 ≈ 2×
+  cost; value errors >0.5 pts ("material flips") are 1.3% @256, 0%
+  @512+. Raw argmax flips are near-ties and the wrong gate.
+- **BR** — exact single-seat best response ("if this one player
+  deviated perfectly, how many points would they gain").
+- **gap** — the certificate: max any single seat could gain (pts/hand)
+  vs the average strategy, priced by exact BR. **gap ≤ 0.05 =
+  converged.** (Registered honesty: CFR's Nash theorem is 2-player;
+  the claim is "low-exploitability reference," not equilibrium.)
+- **rent** — walt-BR-vs-[[jud]] value minus reference value at the same
+  root: the jud-specific share of [[walt]]'s edge. Median +1.5…+1.9
+  pts/root; population −8.65…+15.49.
+- **banked** — the first complete reference line (perf-log 18j):
+  200/200 at gap ≤0.05 in 10.8 wall-hours ≈ **18.5 evals/hr** (rung-0
+  stratum 224/hr). The permanent denominator for every later speedup.
+- **rungs / cascade / verdicts** — `hoyt/refsweep.py`'s budget ladder
+  (rung 0: 90 s wall + 32M slots → rung 1: 600 s + 64M → rung 2:
+  unlimited + 128M). Every (root, rung) attempt is a ledger row with a
+  first-class verdict: `converged` / `gap_capped` (usable at its
+  measured gap) / `slot_capped` / `error`. **slots** = strategy-table
+  entries, the memory currency.
+- **the wedge** — root 555090: 589.6M tree slots (~5× the next
+  biggest), needs rung 2 and ~27 GiB solo, converged at gap exactly
+  0.0. Tree size ⊥ decision difficulty. Since 19g there is exactly one
+  wedge (555212's wedge-hood dissolved under speed).
+- **build / iterate / br / export** — the solve's internal anatomy:
+  lay out the wave-tree arrays; CFR+ update sweeps; gap pricing;
+  profile export.
+- **w5 t4** — production fleet shape: 5 worker processes × 4 numba
+  threads. **paired sweep** — same seeds re-run same-session and
+  compared per-seed (big-root single runs swing ±25% with ambient
+  state; unpaired cross-day numbers are meaningless).
+- **priors / bars / quoted flat** — predictions registered with
+  numeric pass bars *before* measuring; refutations stay in the log at
+  full volume ("PASS by 0.9 s — quote it as 1.11×, not a triumph").
+- **worker-s/eval** — worker-seconds per delivered eval; a pricing
+  tool, explicitly NOT the objective (19c: width beats decontention;
+  throughput is the objective).
+- **churn / pressure** — macOS memory-compressor traffic on the
+  48 GiB box; measured to be run-ordering-determined, not
+  code-determined (19f).
+- **the snake → the pull queue** — work assignment: static
+  interleaved-and-rotated per-worker queues (18h) replaced by one
+  shared biggest-first queue workers pull from via atomic claim files
+  (19i). Balance comes from the pull, not from cost-model precision —
+  exact cost ordering LOST to blunt size ordering by front-loading
+  monsters into simultaneous memory pressure.
+
+## Runtime characteristics, milestone by milestone
+
+hoyt 1.0 (perf-log 18b–18e): σ-compile ≈ 1 net solve, then BR re-solves
+**0.9 ms p50** (45× the net engine; payoff/belief weights swappable);
+H5-cap512 BR 3.5 ms. First CFR: 167 s at eight worlds
+(python-recursion-bound); vectorized onto the wave tree → 4.6 s same
+root, ~2 min and ~7.4 GiB per typical cap-256 root, gap ≤0.05 in ≤40
+iterations regardless of world count. Naive 8-wide sweep: ~45 evals/hr,
+killed by bandwidth contention at 43/200.
+
+Benchmark-root solve wall through PR #83's levers:
+
+| entry | lever | anchor-root solve |
+|---|---|---|
+| 18g (PR #81) | columnar profile: RSS hog was python objects (10.6→6.7 GiB → 5 workers fit) | 120.9 → 92 s |
+| 18l | fused iterate: forced-slot compression (83% of slots provably inert) + numba kernels, bitwise | 88.6 → 41.0 s |
+| 18m | in-struct gap pricing (Fable-credited: "stop walking"), br 16× | 41.0 → 15.9 s |
+| 18n | resident build: stop re-deriving what the walk held | 15.9 → 13.0 s |
+| 18o | gap_exit: intermediates only answer continue-vs-stop | (fleet win) |
+| 18p | walk elisions | 13.0 → 12.6 s |
+| 19a | threaded iterate, bitwise at any thread count; threads=4 | 12.6 → **7.2 s** |
+
+Fleet cost per usable eval: 277 (banked) → 19.5 (18m) → 16.4 (18n) →
+14.7 (18o) → 11.7 worker-s (19a, 20-seed subset) → **15.1 worker-s
+full-population** (19i; the subset was light by ~26%).
+
+Refutation nights (19b–19f), all kept: solo wins compress ~4:1 at
+fleet; width beats decontention every stratum; numpy int argsort is
+already radix (three levers died on it); int32 transients kept as
+bandwidth only (churn theory dead); the banked 174/24/2 rung mix was a
+slow-era artifact — post-speedup in-fleet mix is **197/2/1**.
+
+The line, measured: **19h — 200/200 converged in 17.0 min = 706
+evals/hr (38.1× banked)**, models retired (v1 was right by luck), the
+**measured-exhaustion receipt** for H4-cap-256 micro-perf. **19i —
+snake → pull dispatch, re-measured 990 s = 727 evals/hr (39.3×
+banked)**, all 200 reference values bit-identical, line-level 1.03×
+quoted flat.
+
+## Current state and the fork
+
+Today: 200 H4 evals in 16.5 min (**727/hr**, 15.1 worker-s/eval,
+~7 GiB/rung-0 worker, one 27 GiB wedge running solo). Wall shape:
+rung-0 pool ~62% (balanced ±1 s), wedge ~20% (capped verdict),
+barriers/tails the rest — every bucket has a closed receipt. The
+remaining moves are structural, Jason's to pick: **horizon** (H5/H6
+line — BR measured cheap, CFR line unpriced), **cap policy** (256→512
+≈ 2× for material-flip zero; a cap-512 line is now ~45 min), or **the
+consumer** (lens:ev grading + a distilled student from reference
+values — the [[jud]]-side cash-out the distill-for-what rule names).
+
+## Links
+
+[[perf-log]] · [[perf]] · [[hoyt]] · [[walt]] · [[walt-spec]] ·
+[[jud]] · [[texas-42]]

--- a/wiki/topics/perf-log.md
+++ b/wiki/topics/perf-log.md
@@ -746,3 +746,50 @@ fusion (0.87 s/anchor scale, shared-surface license); (3) _build_fused
 base layout (1.9 s on the big root — casts and seat loops, threadable
 behind the same P13 structure). None registered yet with bars — the
 successor should anatomy (1) first since it is free.
+
+## 2026-07-19c — the zero-diff width experiment: decontention is real and still loses to width; width-per-stratum dies before it was built
+
+Prior P17 registered before the run (`scratch/fused-iterate/p17_prior.md`):
+`--workers 3 --threads 6` (18 threads on 18 cores) paired vs
+`sweep20_p13t4`, same 20 seeds. **P17a (rung-0 root-wall-cum ≤200 s vs
+221.8) CONFIRMED, beaten: 156.2 s (1.42×)** — build bucket 93.4 → 62.8
+worker-s, iterate 55.9 → 41.7, br 40.5 → 30.0; every big-tree root
+improved 1.44–1.91×. Zero verdict flips; full-run wall 360 s unchanged
+(the wedge's solo rung 1+2 dominates at any width). Small roots
+regressed at t6 (555258 0.71×, 555124 0.84× — thread spin-up, P13's
+555319 lesson again); worker RSS maxima rose to 15.3 GiB (fatter
+queues: every worker eventually holds a monster). Box contaminant
+logged: mediaanalysisd ~2 E-cores throughout — margins are far from
+every bar, no re-run.
+
+**Adoption DECLINED, against the letter of the pre-registered rule —
+the rule was mis-specified, and the math goes on the record.** P17b's
+elapsed bar ("20/20 rows by the 90 s tick") passed, but 30 s heartbeat
+granularity cannot resolve elapsed at this fleet size, and the metric
+the north star runs on is steady-state throughput (Little's law:
+width / per-eval root-wall). w5t4: 5/11.67 = **0.428 evals/s**. w3t6:
+3/8.22 = **0.365 evals/s** — a 17% throughput regression hiding under
+a 1.42× worker-seconds "win". Decontention 1.42× < width given up
+5/3 = 1.67×. Per-eval worker-seconds is a pricing tool, not the
+objective; adopting by the rule's letter would have shipped the
+regression to every production sweep.
+
+**The same numbers kill the width-per-stratum lever (19b lever 1)
+before a line was written.** Every stratum loses to width: monsters
+sum 160.1 → 102.8 = 1.56× < 1.67×; top-2 monsters 1.44×; small tail
+≤1.33×. Even the monster stratum packs better at width 5 (160.1/5 =
+32.0 s elapsed vs 102.8/3 = 34.3 s). Exactly one root in 19 beats the
+ratio individually (555039, 1.91×). Width-1 monsters would need ≥5×;
+19b's solo anatomy caps build decontention at ~2.5× on ~half the
+monster wall (~1.7× total) — dead at every width. **w5t4 stands as
+refsweep's production default; law 8's corollary sharpens: width beats
+decontention wherever decontention < width ratio, and on this box that
+is every stratum measured.**
+
+What the zero-diff run bought (why it was the right first move): the
+contention ladder is now priced at three widths (per-eval 11.7
+worker-s @5w / 8.2 @3w / solo floor from 19b), which re-prices lever
+(2): **run_engine gather fusion saves DRAM traffic, and at width 5
+every byte not moved pays twice** — once as the root's own wall, once
+as decontention of four co-runners. That is the next lever; its
+anatomy is free (`build_anatomy_big.py`).

--- a/wiki/topics/perf-log.md
+++ b/wiki/topics/perf-log.md
@@ -316,3 +316,91 @@ runs on the M5 only. B200/Modal port EXPLICITLY DEFERRED until H5 is the
 live frontier (one planned burn, rungs pre-registered). Named consumer:
 distill a student from hoyt reference values; lens:ev grading with the
 reference as leaves.
+
+## 2026-07-18l — the fused iterate landed: 7.1× iterate, bitwise, P6 confirmed / P7 refuted
+
+The [#82](https://github.com/jasonyandell/mk5-main/issues/82) kernel, built
+and gated in one session (branch `fused-iterate`, stacks on PR #81).
+
+**Anatomy first (law 6) — and it inverted the registered picture.** On the
+18g anchor (555006, cap 256): 15.9M isets / 18.8M strategy slots / 19.1M
+edges; forced isets 82.8%, forced slots 70.1% (compress 3.35×), forced
+edges 69.5% — the issue's estimates confirmed. But the phase split
+surprised: `_rm_plus_update` (the slot-space RM+ block) was **72% of
+iterate** (1.06 of 1.47 s/iter), the per-edge wave passes only 0.40 —
+the "gather-multiply-bincount chains" the issue centered were the smaller
+half. The compression lever aimed at exactly the bigger half.
+
+**Landed** (`hoyt/iterkernel.py` + engine="fused", now cfr_solve's
+default; wave stays the pinned pure-numpy mirror, loop the recursive
+oracle):
+
+- **Forced-slot compression, proven exact**: a forced iset is single-slot,
+  so its regret update is cf − cfv ≡ 0 and its σ ≡ 1.0 *exactly*, forever
+  — compression is a bitwise no-op, not an approximation. reg/avg/cf/xI
+  live on non-forced slots only (18.8M → 5.6M), stable-sorted by seat so
+  each seat's update is a contiguous slice (the old block also burned the
+  other three seats' slots every update — 4× more dead work on top of the
+  forced 3.35×).
+- **Fused numba edge kernels**: int32 indices, int8 edge seats, forced
+  edges (cgid = −1) skip the σ gather entirely, pr/pm/pu temporaries never
+  exist. Single-threaded loops replicate numpy's accumulation order
+  (bincount = ascending-edge adds; strict IEEE, no FMA contraction) —
+  **fp64 bitwise parity by construction, verified**: P1/P2/P3 toys+pins
+  0.0e+00, anchor trace/value/gap/exported-profile all exactly equal.
+- Gates: 53 pytest + parity scripts green; jit warm-up runs in the build
+  timing bucket.
+
+**Measured (anchor, quiet box, triad detector 39–46 GB/s throughout):**
+
+| variant | iterate s/iter | vs wave |
+|---|---|---|
+| wave (numpy) | 1.39 (pass 0.39 + update 1.00) | 1× |
+| compression-only (numpy passes + compressed update) | 0.44 | **3.13× — P6 CONFIRMED** (prior: ≥2×) |
+| fused (kernels + compressed update) | 0.196 (pass 0.15 + update 0.046) | **7.1×** |
+
+Anchor solve wall 88.6 → 41.0 s (2.16×). Paired stratified trio (≤10 min
+rule): 555080 2.37×, 555189 2.16×, 555043 1.91× — **1.98× aggregate**,
+bitwise PASS on every root.
+
+**P7 REFUTED, and deleted.** fp32 was built, measured, and removed in the
+same session: gap drift 2.59e-3 on the anchor (over the 1e-3 license bar;
+reference value moved 3.2e-2), AND **zero throughput win** — 0.194 vs
+0.195 s/iter, because the fused loops are gather-latency-bound, not
+float-bandwidth-bound. The 18k framing ("2× on all slot traffic") priced
+bytes, but after fusion the iterate stopped paying in bytes. No speedup +
+no consumer + drift over bar ⇒ the dtype knob is gone (receipts here; the
+possible revisit is the *contended multi-worker* regime, where aggregate
+DRAM pressure — not single-stream latency — is the wall, and only if a
+tighter numerics story caps the drift).
+
+**Amdahl bookkeeping (law 7):** iterate fell from 62% of solve wall to
+~19%; **exact-BR gap pricing is now 65–71% of wall** (26.5 s of 41 on the
+anchor; 84 of 117 on 555043). The next solve-wall lever is the
+mixed-profile BR walk / gap-measure cadence (`br_every`, queued since
+18e), NOT more iterate work. numba is now a runtime dep of the default
+engine (CONTRACTS.md updated; wave/loop remain numba-free).
+
+**Velocity, measured the honest way** (20-root stratified sample = 10% of
+the anchor, 5 workers, rung-0 ladder, production `refsweep` sharding):
+20/20 rows in 360 s — 17 converged, 2 gap_capped, 1 slot_capped (the
+555090 wedge, as banked). Same-seed same-rung pairing vs the 18j
+production ledger: **2,898 → 808 worker-seconds, 3.59×** on the 17
+both-converged roots. The per-root spread (1.24×–9.8×) is the law-8
+corollary in reverse: the banked contention victims (555008 954 s,
+555045 986 s) fell 9–10× because five fused workers no longer saturate
+DRAM — small roots kept completing straight through monster phases
+(loadavg 3–5). Peak worker RSS 5.8 GiB on converged roots (was 7.0).
+Projected rung-0 velocity ≈ 3.6 × 224 ≈ **~800 H4 evals/hour** (the
+sample's naive 190/h is tail underutilization on a 20-root batch — 1,800
+worker-s allocated, 1,231 spent; don't quote it). The projection gets
+banked as a measured number at the next full production sweep (H5 ladder
+or evalset v2) — rerunning the closed v1 line would only reproduce
+bitwise-identical rows.
+
+One verdict flip, by design: 555039 banked *converged* at 1,837 s (it
+blew far past the 90 s budget before its first gap measurement — 
+convergence beats the cap) but *gap_capped* here at 149 s, because the
+faster engine reached a budget checkpoint first. Wall stops are
+timing-dependent (exactly why engine="loop" refuses `wall_budget_s`);
+the cascade carries the root to rung 1 unharmed.

--- a/wiki/topics/perf-log.md
+++ b/wiki/topics/perf-log.md
@@ -595,3 +595,54 @@ surface) and the iterate floor itself. Session total on the anchor:
 (predict crossing from gap decay — saves another ~½ step), run_engine
 gather fusion (the big license), or bank the line and spend the
 velocity on H5/evalset-v2 instead.
+
+## 2026-07-18p — walk elisions land small, a buggy anatomy copy refuted honestly, and the parallel-iterate lever registered
+
+**PB5 registered** (walk 1.15 → ≤0.70 s, fused build 2.49 → ≤1.9 s on
+the anchor), on the strength of a timed structural copy of run_engine
+that ran the walk in 0.48 s. **PB5 REFUTED, both clauses — the copy was
+buggy.** It used the hero_is_me hands line, so `col_arr[me] == -1`
+silently negative-indexed the LAST world column instead of mymask —
+wrong hands, wrong legality, an 8.2M-slot tree instead of the real
+19.1M. The phantom 0.6 s of "headroom" was a smaller tree. Law-6
+corollary, earned twice tonight: **an anatomy copy that does not
+reproduce the tree is not an anatomy** — print the tree size before
+believing the clock (the buggy script is kept in scratch as the
+receipt).
+
+**What actually landed (all value-identical, gates green):** lazy
+`starts_node` (only the hero branch consumes it; the hero=-1 walk never
+did), `_cat2` empty-side concatenate elision (the full-width walk
+concatenated an empty hero side into every slot array every wave),
+minority-write `hands` (in-place assignment on me-slots instead of a
+full-width np.where), and the export's move emission routed through
+`fw_fill` (killing the last big (isets×28) bool + nonzero in
+_build_wave). Measured: walk 1.15 → **1.08 s (1.06×)**, fused build
+2.49 → **2.20 s (1.13×)**, anchor solve 13.0 → **12.6 s**, bitwise PASS
+(trace/value/profile vs wave; P8 3.6e-15; banked 2.2e-07). No sweep run:
+1.13× on a 33% bucket ≈ 4% fleet — at the ±4% noise floor
+([[perf]] law; perf-subset-5), the anchor receipts carry it.
+
+**The real walk anatomy** (in-memory instrumentation of run_engine
+itself, NOT a copy): slot-gather+mask 0.31 s / numba fill+legality
+0.20 / prep+hands 0.11 / transitions 0.08 / sort+seg 0.10 / hash+stores
+0.09. It is E-scale-fancy-gather-bound. A fused σ-branch kernel
+(gather+mask+wt+world+pslot in one pass over rows) caps at ~0.3 s/anchor
+≈ 3–4% fleet — **registered as a cap verdict, low priority; do not build
+without a cheaper reason.**
+
+**Registered next lever — parallel fused iterate (P13).** Iterate is
+45% of fleet wall and single-threaded by the 18l bitwise doctrine. The
+doctrine survives threading IF every thread owns a DISJOINT output
+range with unchanged within-range accumulation order: fwd is a pure
+map (trivially parallel); bwd's `v_p[p] +=` partitions at parent-slot
+boundaries (edges are parent-sorted — disjoint outputs, ascending order
+within each parent preserved ⇒ bitwise regardless of scheduling); the
+`cf_c[g] +=` accumulation is the hard part (an iset's slots span
+non-adjacent parents) — precompute a per-wave permutation grouping the
+updating seat's edges by gid at build time (structure, cached in
+_FusedLayout), turning cf into segmented sums parallel by group range
+with ascending-edge order inside each group. **P13 prior: ≥1.8× iterate
+on the anchor at 4–8 threads, bitwise vs single-thread fused, RSS flat.**
+Risk: numba prange scheduling must not touch output ranges — chunk
+boundaries must be precomputed structure, not runtime heuristics.

--- a/wiki/topics/perf-log.md
+++ b/wiki/topics/perf-log.md
@@ -482,3 +482,68 @@ compile_sigma/br_solve/CFR — a much bigger license, lever-after-next.
 
 Amdahl after 18m: **build 43% / iterate 38% / export+br+value ~13% /
 oracle phases ~6%** — the referee is no longer priced by its pricing.
+
+## 2026-07-18n — the build lever: stop re-deriving what the walk held (pslot/actor resident, numba fill)
+
+The registered lever was "numba expand_full_width" (18m: build 43% of
+worker wall, but shared parity surface under compile_sigma/br_solve/CFR —
+a big license). **Sub-anatomy first (law 6), and it shrank the license.**
+Priors: PB1 walk ≤35% / post-walk ≥50% / _build_fused ≤15% of anchor
+build; PB2 the unique + PS-reconstruction argsorts ≥50% of post-walk.
+Measured (anchor, triad 39–42 GB/s): build 5.90 s = walk 2.28 (39%) +
+post-walk 3.08 (52%) + _build_fused 0.54 (9%) — PB1 confirmed on
+post-walk, hair over on walk. **PB2 half-REFUTED**: np.unique is 0.15 s
+(numpy 2.4's hash-based unique — the argsort fear is stale); the real
+cost is **searchsorted 2.04 s**, re-deriving per wave (a) the parent slot
+of every child slot by (node, world)-key binary search and (b) the actor
+per node via first-child search — both of which `run_engine` already held
+as locals (`rows`/`gidx` ARE the parent-slot indices; `actor` is
+computed per wave). The 18m lesson generalizes: the fix is not to fuse
+the search; it is to stop searching.
+
+**Landed, two parts, both output-identical by construction:**
+- **A (structural, no numba):** `keep_slots` now also stores per-wave
+  `pslot` (int32 parent-slot per child slot) and `actor` (int8 per node).
+  `_build_wave` reads them; the searchsorted reconstruction is deleted
+  (no-legacy). License: additive fields on the CFR-lane-only
+  `keep_slots=True` path — br/compile_sigma call run_engine with
+  keep_slots=False and never execute the new lines. Gate: old derivation
+  replicated in scratch and asserted EXACTLY equal on all 16 anchor waves
+  + a durable toys invariant in test_full_width_walk.
+- **B (numba, provider-scoped):** `hoyt/buildkernel.py::fw_fill` emits
+  (slot, move) pairs straight off the legal bitmasks in np.nonzero's
+  row-major order, killing the per-wave (slots×28) bool matrix + 1.03 s
+  of nonzero. Selected by `_FullWidthProvider(kernels=True)`, threaded
+  as `_build_wave(kernels=fused)` — **the numpy provider stays the
+  pinned mirror and the wave lane stays numba-free** (CONTRACTS.md), so
+  the standing fused-vs-wave bitwise gates now cover the build too.
+  Gate: kernels walk == mirror walk, every field of every wave + leaf,
+  exact.
+
+**Measured (anchor 555006, cap 256, 40 iters):** fused-lane build 5.90 →
+**2.49 s (2.36×)**; solve wall 15.9 → **13.0 s** (88.6 at 18k start:
+**6.8×**). Bitwise PASS (trace/value/gap/profile vs wave; P8 oracle
+3.6e-15; banked row 2.2e-07 within the 1e-6 rounding license). All
+parity gates green (P1–P4, 53 pytest).
+
+**P10-style sweep** (same 20 roots, 5 workers — full cascade this time,
+18m ran --rungs 0): paired both-converged **235 → 194 worker-s = 1.21×
+vs 18m** — registered prior **P11 (≥1.25×) NARROWLY REFUTED**: small
+roots pay fixed overheads (subgame build, jit-warm, worlds) that the
+2.36× doesn't touch; fleet build bucket moved 165.8 → 94.6 s (1.75×),
+not 2.36×. Banked/18n on the paired subset: **14.97×**. Per usable eval
+(19 seeds, ladder accounting): 19.5 → **16.4 worker-s** (1.19× vs 18m,
+**16.9× vs banked**); projected rung-0 velocity ~**2,400–3,300
+evals/hour**. Bonus receipt: the 555090 wedge, slot_capped in every
+rung-0-only sweep, laddered to rung 2 and **converged in 366 s** (banked
+paid 1,799 s for that verdict) — peak RSS 27.0 GiB at cap 1024 on the
+48 GiB box, fine solo but confirms rung-2 solves must not share the box
+with 4 siblings (the L4 kill holds).
+
+Amdahl after 18n (rung-0 fleet, wedge excluded): **iterate 50% / build
+31% / br 12% / export 5%** — the wheel turns back to iterate. Next lever
+per the queue: **L3 adaptive gap cadence** (pricing is 0.4 s; measure
+every 5 iters and stop at first crossing — the tail iterations after
+the gap crosses are pure waste, ~25% of iterate). expand_full_width
+deeper fusion (run_engine's own gathers, 0.87 s/anchor) is now the
+lever-after-next and still carries the shared-surface license.

--- a/wiki/topics/perf-log.md
+++ b/wiki/topics/perf-log.md
@@ -877,3 +877,53 @@ attacking the measured 2× pressure multiplier where it lives, and
 narrowed in 18n already; this is the transient side. Dtype-promotion
 traps (numpy silently upcasting mixed int32/int64 expressions) make
 this a parity-gated structural change — workflow/subagent sized.
+
+## 2026-07-19f — int32 walk working arrays: kept as a bandwidth win; the transient-pressure theory refuted flat (churn is ordering, not dtype)
+
+Priors + bars registered before code
+(`scratch/fused-iterate/int32_prior.md`). Change: `run_engine`'s
+transient slot arrays narrowed — `sw` (M,3) and `sworld` int64 → int32
+(28-bit masks / world ids ≤ 256); `snode` STAYS int64 (index array,
+18g, and `snode<<5` keys pass 2^31 near the slot budget); the stored
+per-wave copies become `astype(np.int32, copy=False)` aliases (the
+walk rebinds sw/sworld per wave and never writes them in place —
+`sw_sig` is a gather copy); the σ bit-clear goes through an int32
+clear-mask LUT (`_NB28_I32`) because `&= ~(_I64_1 << mv)` would
+promote; `worlds_i64` retired for `worlds_i32` (br.py's grouped BR
+included). Parity gate: value-normalized hashes of every wave array +
+leaf + counters vs HEAD's walk, 3 roots × kernels on/off — EXACT;
+53 pytest green.
+
+**Measured on TWO wedge pairs, both orderings — the reversal earned
+its keep.** Compressor churn is position-determined, not
+code-determined: first arm ~35.3/35.5 GiB, second arm ~31.7/31.1,
+whichever code ran. **I1 (churn ≤0.70×) REFUTED FLAT: the coupling
+from transient write traffic to compressor churn is ≈0.** The ~19
+GB/build of removed transient writes never reach the compressor
+(hot, short-lived pages); the churn lives in the RESIDENT stored
+waves. 19e's "attack the 2× pressure multiplier via transients"
+theory is dead — a future pressure lever must shrink resident
+footprint, not transients. maxrss is position-determined too (first
+arm 26.2/26.5, second 28.5/28.3 — inverted vs the naive read); I2
+unmeasurable by this design. Wedge iterate swung 37.9 → 64.5 s
+between back-to-back pairs at fixed code — **±25% ambient
+sensitivity; wedge bars need paired same-session arms, always.**
+
+**The mechanism-pure win, consistent across orderings**: walk 50.8 →
+43.1 and 50.3 → 44.2 s (**1.16×**), build 1.07× both pairs; wedge
+solo wall ≈0.97× position-corrected (I3 bar ≤0.95 MISSED, quoted
+flat), in-sweep wedge 233.7 → 232.8 (wash). Fleet gate: 20-seed
+paired sweep, zero verdict flips, rung-0 root-wall-cum **221.8 →
+221.8 s — 1.000×** (19d's compression law, third sighting), build
+bucket 93.4 → 88.7 worker-s, worker RSS max 28.3 → 27.5 GiB.
+
+**Verdict: KEPT, with the primary bar refuted and the override named
+(19c template).** I1 priced a coupling measurement puts at ≈0 — no
+transient-dtype change could ever have passed it; it was a bar on a
+wrong theory, not on the lever. Every decision variable that COULD
+move passed: parity exact, wall non-regression (0.97–1.00×), fleet
+gate green, transient bytes/build −~19 GB (the north star's second
+axis). Unlike 19d's deleted kernel this is not a second lane — a
+dtype in the single implementation, net −1 module attribute. The
+residual liability is the alias invariant (stored waves must never
+be written in place), documented at the store site.

--- a/wiki/topics/perf-log.md
+++ b/wiki/topics/perf-log.md
@@ -2,7 +2,7 @@
 title: Perf log — append-only field notes
 kind: topic
 first_seen: 2026-07-18
-last_updated: 2026-07-18
+last_updated: 2026-07-19
 status: active
 ---
 
@@ -646,3 +646,65 @@ with ascending-edge order inside each group. **P13 prior: ≥1.8× iterate
 on the anchor at 4–8 threads, bitwise vs single-thread fused, RSS flat.**
 Risk: numba prange scheduling must not touch output ranges — chunk
 boundaries must be precomputed structure, not runtime heuristics.
+
+## 2026-07-19a — P13 lands: threaded iterate, bitwise by construction; refsweep threads=4
+
+**Sub-anatomy first (law 6), and it refuted the premise before a line of
+kernel code.** Registered PA1 (bwd ≥55% of anchor iterate) — REFUTED:
+fwd 48% / bwd 28% / rm_plus 22% / loop 2%, so rm_plus threading is
+mandatory, not optional. PA3 (PS parent-sorted, 18p's design premise) —
+**REFUTED: PS is neither sorted nor contiguous-by-parent** (mono_frac
+0.78–1.0, runs ≫ uniq on waves 0–11 of the anchor). The 18p design as
+written dies; the surviving design is stronger and simpler: **group
+edges by output owner with build-time stable argsorts** (structure in
+`_FusedLayout`, never runtime heuristics) — by parent for `v_p`, by gid
+for `cf_c`, by iset for the CFR+ update. Each numba `prange` iteration
+owns a disjoint output range and folds its contributions in ascending
+edge order (= np.bincount's fold), so results are **bitwise identical
+at any thread count and any scheduling**. Trick-tail waves 12–15
+(11.9M of 19.1M edges) are parent-bijections — pure-map fast path, no
+permutation stored. Verified before believing: np.maximum returns +0.0
+on ±0.0 ties (mirrored by the clamp), and a +0.0-seeded IEEE fold can
+never produce −0.0, so register-accumulate-then-store is exact.
+
+**Landed:** `cfr_solve(threads=N)` (fused-only; wave/loop mirrors stay
+the pinned single-threaded references and raise), five kernels in
+`hoyt/iterkernel.py` (`fwd_edges_par`, `bwd_v_map`, `bwd_v_seg`,
+`cf_seg`, `rm_update_seg`), perm build in `_build_fused(par=True)`,
+refsweep `--threads` (default 4). **Gate P13 added to the parity
+suite** (threads 3/4 + gap_exit compose, exact-zero drift); P1–P5
+green, 53 pytest green.
+
+**Measured (anchor 555006, cap 256):** iterate **2.67× @4 threads,
+3.12× @8** (prior ≥1.8× CONFIRMED, beaten), bitwise PASS at every
+count; anchor solve 12.6 → **7.2 s**. RSS honestly **+0.21 GiB (+5%)**
+in isolated runs — not strictly flat (perms + numba parallel runtime);
+fleet worker maxima unchanged (28.5/14.4/11.2 → 27.9/13.4/11.4).
+
+**Measured (same 20 roots, 5 workers, full cascade), the thread ladder
+with per-config priors:**
+- **P14 (t2: rung-0 wall ≤240 s) NARROWLY REFUTED at 245.9 s** — by
+  5.9 s; quote it as 1.13×, not a triumph.
+- **P15 (t4: ≤ t2 AND full-run ≤320 s) SPLIT**: rung-0 **221.8 s
+  (1.26× vs 18o's 279.1)** confirmed; full-run 360 s REFUTED — the
+  wedge's solo rung-2 is not iterate-bound (250 → 234 s, t2 → t4).
+- **P16 (t8: rung-0 ≤210 s else t4 default) NARROWLY REFUTED at
+  215.4 s** — t8/t4 = 1.03×, inside the ±4% noise floor at 40 threads
+  on 18 cores. **threads=4 is the production default by P16's own
+  decision rule.**
+
+Zero verdict flips in any config; every stopping gap a full-priced
+≤0.05 certificate. The anchor's 2.67× compresses to fleet 1.26×
+because small roots pay thread overhead (555319: 0.62×) and iterate
+was 45% of fleet wall. Fleet iterate bucket 207.6 → **101.8 worker-s
+(2.04×)**; per usable rung-0 eval **14.7 → 11.7 worker-s (23.7× vs
+banked)**; full-cascade root-wall-cum 578 → 473 s; projected rung-0
+velocity **~3,400–4,650 evals/hour** (was ~2,700–3,700).
+
+Amdahl after 18q (rung-0 fleet, t4): **build 48% / iterate 23% / br
+17% / export 10%** — the wheel turns back to build, and the two big
+build levers are known: run_engine's own gathers (the shared-surface
+license, 18n's lever-after-next) and the per-root fixed overheads that
+kept P11 honest (subgame build, jit-warm, worlds). Cap verdicts kept:
+threads on the solo rung-2 wedge are marginal (234–250 s at any
+count); σ-branch gather kernel stays capped at 3–4% fleet (18p).

--- a/wiki/topics/perf-log.md
+++ b/wiki/topics/perf-log.md
@@ -927,3 +927,25 @@ axis). Unlike 19d's deleted kernel this is not a second lane — a
 dtype in the single implementation, net −1 module attribute. The
 residual liability is the alias invariant (stored waves must never
 be written in place), documented at the store site.
+
+## 2026-07-19g — the second wedge dissolves: 555212 converges at rung 0; the production model has ONE wedge
+
+Prior registered (`scratch/fused-iterate/sw_prior.md`): SW1 =
+still-wedge-class (slot-caps to rung 2, 180–320 s) vs SW2 = the
+19e-shaped alternative (converges rung ≤1, ≤120 s). **SW2 CONFIRMED
+beyond its bar: 555212 converged AT RUNG 0 — 72.2 s wall, 60 iters,
+gap 0.039 (banked 1332.4 s = 18.5×, the same ratio class as 555095's
+17.8×).** SW1 refuted; the banked-rung-2 stratum was half artifact.
+Caveat carried forward: its rung-0 solve held 27.4 GiB maxrss — in a
+width-5 fleet that co-residency is untested (the memory-aware cap
+only guards rungs 1–2); the full-line run is the test.
+
+**Production model v2 (model, not measurement):** the wedge share of
+the full line halves — 19e's "two wedges ~2×250 s ≈ half the wall"
+becomes ONE wedge (555090, 232.8 s in-sweep post-int32, ~30% of
+wall) plus 555212 folding into the width-5 rung-0 pool (~72
+worker-s, noise at pool scale). Est. full-line wall ~515 s width-5
+pool + ~233 s wedge ≈ **~12.5 min ≈ ~960 evals/hour (~52× banked)**.
+The soft spot is unchanged (the 174 banked-rung-0 roots' true
+average) — which is the argument for measuring: the split design the
+19e handoff named (two ≤10-min runs) replaces model v2 next.

--- a/wiki/topics/perf-log.md
+++ b/wiki/topics/perf-log.md
@@ -10,7 +10,8 @@ Append-only field notes for performance work, per Jason's 2026-07-18
 directive: this log replaces GitHub issues for the perf program. Entries are
 terse but rich — what was tried, how the numbers moved, what died. Newest at
 the bottom. Laws distilled from here graduate to [[perf]]; never edit old
-entries (corrections are new entries).
+entries (corrections are new entries). Cold readers: the shorthand is
+decoded in [[hoyt-perf-primer]].
 
 ## 2026-07-18a — program registration: the net-free kernel
 

--- a/wiki/topics/perf-log.md
+++ b/wiki/topics/perf-log.md
@@ -793,3 +793,46 @@ worker-s @5w / 8.2 @3w / solo floor from 19b), which re-prices lever
 every byte not moved pays twice** — once as the root's own wall, once
 as decontention of four co-runners. That is the next lever; its
 anatomy is free (`build_anatomy_big.py`).
+
+## 2026-07-19d — walk gather fusion: built, measured at both scales, refuted at both bars, deleted; the P11 compression law reaches the build
+
+Walk sub-anatomy on 555046 first (priors PW1–PW4,
+`scratch/fused-iterate/pw_prior.md`): walk 5.64 s = expand 1.17 (21%)
++ **argsort 0.22 (4%)** + cat2 0.00 (the hero-less full-width walk
+never concatenates) + remainder 4.25 (75%). PW1 (argsort ≥25%)
+REFUTED — numpy's radix argsort wins a THIRD time (PB2 → PB8 → PW1;
+stop pricing numpy integer sorts by comparison-sort intuition,
+permanently). PW4 (fusable gather surface ≥35%) CONFIRMED at 75%.
+
+**PW5 built**: `walk_gather` numba kernel — the σ-path's six
+slot-scale passes (rows/skey gathers, sw gather + actor/col
+double-gather + bit-clear scatter, swt, sworld) fused into one prange
+map, pure gather-of-gather, disjoint outputs, no folds → bitwise at
+any thread count by construction. Exact-parity gate PASS (three roots,
+threads 1+4, every wave array + leaf + pslot), 53 pytest green.
+
+**Measured, quoted flat: solo bar MISSED** — walk 5.64 → 4.22 s
+(1.34×, bar ≤3.8), build 11.97 → 10.83. **Fleet bars REFUTED** (same
+20-seed paired sweep, w5 t4): build bucket 93.4 → 87.4 worker-s
+(1.07×, bar ≤80); rung-0 root-wall-cum 221.8 → **223.2 s — a wash**
+(bar ≤208); zero verdict flips. The registered honesty clause fired:
+the removed passes did not buy back co-runner decontention — **19c's
+double-pay theory takes its hit**. Deleted same-session (fp32/PB8
+precedent); receipts stay in scratch (walk_anatomy_big.py,
+walk_gather_gate.py — the gate still validates fw_fill's mirror).
+
+**The lesson with a number: solo walk wins compress ~4:1 at fleet** —
+−1.14 s on the specimen became −6.0 worker-s across 19 roots because
+the walk is only the monster-share of build. This is P11's law
+reaching the build bucket: anchor-scale (now specimen-scale) wins
+never fully cash fleet; the compression ratio is the monster-share of
+the touched surface. Post-walk assembly (~4.6 s solo, the biggest
+remaining build chunk) is PRE-PRICED by the same math: expect ~1.05×
+fleet from a 2× solo win — not worth kernel work without a
+structural elision that applies to every root.
+
+**Kept from the spike**: `numba.set_num_threads` hoisted above
+`_build_wave` in `_solve_wave` — it previously ran after the build, so
+any future numba-parallel kernel reached from the walk would default
+to all cores and oversubscribe a 5-worker sweep 5×18-on-18. Real bug,
+zero-cost fix, landed.

--- a/wiki/topics/perf-log.md
+++ b/wiki/topics/perf-log.md
@@ -949,3 +949,39 @@ pool + ~233 s wedge ≈ **~12.5 min ≈ ~960 evals/hour (~52× banked)**.
 The soft spot is unchanged (the 174 banked-rung-0 roots' true
 average) — which is the argument for measuring: the split design the
 19e handoff named (two ≤10-min runs) replaces model v2 next.
+
+## 2026-07-19h — the full line, measured: 200/200 converged in 17.0 min — 706 evals/hour, 38× banked; model v1 was right for wrong reasons
+
+Priors FL1–FL4 registered (`scratch/fused-iterate/fl_prior.md`).
+Design: the split the 19e handoff named — 200 evalset roots in two
+interleaved halves, each a full production cascade (w5 t4), each
+**510 s wall** (both under the 10-min bench cap; the split's 2×
+spin-up + 2× rung barriers make it a conservative overstatement of
+single-line wall).
+
+**Headline: 1,020 s total for 200/200 CONVERGED — zero gap-capped
+finals, zero errors (FL3 PASS beyond its bar) = 706 evals/hour
+measured** (banked line 10.8 h ≈ 18.5/hr → **38.1×**). Per-eval:
+2,953 worker-s / 200 = **14.8 worker-s/eval** — the full population
+is ~26% heavier than the 20-seed subset's 11.7; the model's
+174-root soft spot was real.
+
+**FL1 (≤900 s) REFUTED at 1,020. FL2 (±20% of model v2's ~750 s)
+REFUTED at +36% — and model v1's "~17 min ≈ ~700/hr" (19e) was
+accidentally EXACT**: its phantom second wedge (~250 s that does not
+exist, 19g) cancelled its underpriced rung-0 pool (measured ~631 s
+elapsed vs ~515 modeled). Two wrong terms, right sum — a model that
+validates by luck is still wrong; the measurement replaces both
+models.
+
+**FL4 fired, informatively: 555212 LADDERS in production.** Its solo
+rung-0 convergence (72.2 s, 19g) is wall-cap-marginal against the
+90-s rung-0 cap; width-5 contention pushed it over, it gap-capped
+and converged at rung 1 (135 s, width 2, rss 13.4). The cascade
+self-corrects at the price of one failed attempt. In-fleet rung mix:
+**197 / 2 / 1** (rung 1 = 555095 138 s + 555212 135 s; rung 2 =
+555090, 208 s, rss 27.6 — its best time yet). Measured line Amdahl:
+rung-0 pool ~62% of wall, the wedge ~20%, barriers/tails the rest —
+the pool is 19c's closed question, the wedge is 19a's cap verdict.
+**At this altitude the line is priced by measurement; this is the
+measured-exhaustion receipt for the perf push at H4-cap-256.**

--- a/wiki/topics/perf-log.md
+++ b/wiki/topics/perf-log.md
@@ -547,3 +547,51 @@ every 5 iters and stop at first crossing — the tail iterations after
 the gap crosses are pure waste, ~25% of iterate). expand_full_width
 deeper fusion (run_engine's own gathers, 0.87 s/anchor) is now the
 lever-after-next and still carries the shared-surface license.
+
+## 2026-07-18o — gap_exit: the cadence economics invert when intermediates only answer yes/no
+
+L3 as queued said "measure every 5–10 iters". The trace economics said
+otherwise: a full 4-seat measurement costs 3.5–7 iterations equivalent
+(measured per root, 18n sweep), so k* = √(2·T·c_meas/c_iter) ≈ 16–18 —
+**br_every=20 was already near-optimal for FULL pricing**, and densening
+it would have lost money. The unlock is structural: an intermediate
+measurement only decides continue-vs-stop, and gap > target ⇔ SOME
+seat's BR gain > target — so price seats in descending last-known-gap
+order and **exit at the first crossing**. Intermediates then cost ~1
+seat, the ratio drops to ~1.3–2, and k* ≈ 9–11.
+
+**Landed:** `cfr_solve(gap_exit=True)` (wave/fused; the loop mirror
+raises, wall_budget_s precedent) + refsweep `BR_EVERY 20 → 10`.
+Exactness is by construction, not tolerance: convergence is only
+declared after ALL live seats are priced; any measurement that can end
+the solve without convergence (iters exhausted, wall budget) prices all
+four (a capped row's final_gap stays a full verdict; a budget expiry
+during a partial measurement defers the cap to the next, full, one). So
+the stop iteration and final profile/value/gap are IDENTICAL to
+gap_exit=False at the same cadence — only intermediate trace entries
+change (certified-above-target partial maxima). **Gate P5** (parity
+suite): stop iter + final result exactly unchanged on toys tuned to
+force 23 intermediate exits. All gates green, 53 pytest.
+
+**Measured (same 20 roots, 5 workers, full cascade):** **P12
+(registered: 19-seed rung-0 wall 310.8 → ≤280 s) PASS at 279.1 s — by
+0.9 s; quote it as 1.11×, not a triumph.** Mechanism receipts: 8/19
+roots stop one cadence step earlier (555046: 20 → 10 iters, 61.4 →
+52.3 s), iterate bucket −19% (151.6 → 123.2 s), br bucket flat
+(36.8 → 37.7 s — the doubled cadence fully paid for by seat-exit),
+zero verdict flips, every stopping gap a full-priced ≤0.05
+certificate. The new rows stop less-converged (555258: gap 0.0499 vs
+18n's 0.0286) — that is the protocol working: pay only for the
+certificate, not for polish past it. Per usable eval (19 seeds, ladder
+accounting): 16.4 → **14.7 worker-s = 1.12× vs 18n, 18.9× vs banked**;
+wedge ladder 700 → 578 s cum. Projected rung-0 **~2,700–3,700
+evals/hour**.
+
+Amdahl after 18o: iterate 45% / build 33% / br 14% / export 6%. The
+big single-root buckets are now build's run_engine gathers (shared
+surface) and the iterate floor itself. Session total on the anchor:
+88.6 → 13.0 s solve; fleet per-usable-eval 277 → 14.7 worker-s
+(**18.9×**). Next candidates, none registered yet: adaptive cadence v2
+(predict crossing from gap decay — saves another ~½ step), run_engine
+gather fusion (the big license), or bank the line and spend the
+velocity on H5/evalset-v2 instead.

--- a/wiki/topics/perf-log.md
+++ b/wiki/topics/perf-log.md
@@ -985,3 +985,48 @@ rung-0 pool ~62% of wall, the wedge ~20%, barriers/tails the rest —
 the pool is 19c's closed question, the wedge is 19a's cap verdict.
 **At this altitude the line is priced by measurement; this is the
 measured-exhaustion receipt for the perf push at H4-cap-256.**
+
+## 2026-07-19i — the tail-idle lever: static shards die, pull-based dispatch lands; balance comes from the pull, not the cost model — line re-measured 727 evals/hour
+
+The handoff's one unpriced move: rung-0 fleets dropped to 2/5 alive
+near the tail. Priors TI1–TI5 + FL5 registered before every number
+(`scratch/fused-iterate/ti_prior.md`).
+
+**Stage A (simulation, free)**: the 19h line's 200 measured per-root
+walls replayed under candidate schedulers. Static LPT packing is DEAD
+ON ARRIVAL — by-sigma it *pessimizes* (0.61–0.73× vs the snake:
+estimate error compounds in a fixed partition); even by banked walls
+(rank-corr 0.889 with fresh walls) it's a wash. Pull-based dispatch
+tracks the perfect-balance floor with any reasonable order: ceiling
+1.117× (h1) / 1.282× (h2) of rung-0 makespan.
+
+**Stage B (5 paired arms, h2-even 50 roots, rung-0 only, one
+session)**: static 126.2/125.3 s; dyn-sigma 106.9/108.5 s; dyn-banked
+117.6 s. **Keep bar (≥1.15×) passed in BOTH orderings: 1.181× and
+1.155×.** The night's insight: **the sharper cost model LOST.**
+Banked-wall ordering front-loads the true monsters into simultaneous
+residency and pays +13.6% cum contention inflation; sigma's noisy
+ranking (0.622) decorrelates the heavy phases (+3–5% cum) and the
+pull self-balances regardless — every dynamic arm's shards landed
+within ±1 s. The old snake's stagger insight, reborn inside the pull.
+`--cost-file` built, measured, DELETED (no-legacy). Parity across all
+arms exact (verdict/gap/iters/reference value per seed). Residual
+quoted flat: sigma order can strand one ~37 s root (555233) in the
+last-40 dispatches — ≤~30 s tail exposure, the sim's sigma-vs-oracle
+gap; accepted, contention dominates.
+
+**Ship + full-line re-measure (FL5, same split as 19h)**: h1 540 s +
+h2 450 s = **990 s for 200/200 converged = 727 evals/hour (39.3×
+banked), 15.1 worker-s/eval**. FL5a (≤960 s) REFUTED at 990 — quote
+1.03×, not a triumph: h1's snake partition was already near-balanced
+(1.037× realized) and sigma inflation ate +5.8% of its cum; h2's
+pool, the imbalanced one, gave the real win (347.6 → 279.2 s
+makespan, 1.245×, cum flat). Rung mix 197/2/1 reproduced with the
+SAME three roots (555212 ladders again — its marginality is stable
+under the new order), and **all 200 merged reference values are
+bit-identical to the 19h line**: scheduling moved, nothing else did.
+Code: `plan_shards` → `dispatch_order` + atomic claim files
+(`hoyt/refsweep.py`), net simpler; 53 tests green. The
+measured-exhaustion receipt now includes the scheduling family:
+pools balance to ±1 s, so residual line wall is contention
+inflation + the wedge + barriers — all previously priced.

--- a/wiki/topics/perf-log.md
+++ b/wiki/topics/perf-log.md
@@ -836,3 +836,44 @@ structural elision that applies to every root.
 any future numba-parallel kernel reached from the walk would default
 to all cores and oversubscribe a 5-worker sweep 5×18-on-18. Real bug,
 zero-cost fix, landed.
+
+## 2026-07-19e — the rung-1 stratum dissolves, the production model turns over, and the wedge is priced: 5× big, 2× memory-pressured
+
+**PR1 (rung-1 pricing) refuted its own framing, which is the finding.**
+Sample = banked rung-1 min/p25/p50/p75/max (555037/555304/555104/
+555071/555095) through the normal cascade: **4 of 5 converge AT RUNG 0
+now** (14.0–37.2 s; banked 109–453 s) — the banked 174/24/2 rung mix
+is an artifact of banked-era speeds, not tree structure. Only the
+banked max still ladders: 555095 rung-1 converged **77.4 s vs 1376.8
+banked (17.8×)**; my mean-bar was ill-posed (one survivor), the
+max-root bar (≤120 s) CONFIRMED, zero verdict flips.
+
+**Production velocity model v1 (model, not measurement — quote it as
+such):** extrapolating the sample, ~193/200 roots are rung-0-class
+post-P13. Est. full-line: ~174×≲10 + ~19×21 + ~5×87 worker-s at
+width 5, plus the two wedges ~2×250 s at width 1 (mem cap) ≈ **~17 min
+wall ≈ ~700 evals/hour full-line — ~37× banked** (banked line: 10.8 h,
+18.5/hr). The full post-P13 line has NOT been run end-to-end (>10-min
+bench cap); the model's soft spot is the 174 banked-rung-0 roots' true
+average. **The wedges are ~half the modeled wall, at width 1 — the
+production Amdahl points at the wedge class, where solo wins cash 1:1
+(19d's compression law does not apply).**
+
+**Wedge anatomy (PW6–PW8 registered, one solo rung-2 solve):** build
+118.6 s of 234 s wall. **PW6 CONFIRMED beyond its bar: 589.6M total
+tree slots — 5.0× 555046** (the slot budget is per-WAVE; totals
+diverge). Per-slot build 201 vs 102 ns/slot → a clean **2× residual**,
+and **PW8 CONFIRMED: 32.7 GiB compressor churn** during the solve
+(maxrss 26.4 GiB on the 48 GiB box; triad degraded 45.5 → 31.8 GB/s
+across the run). The wedge is big×pressured, both terms now measured.
+Walk shape at scale: 50.8 s = expand 13% / argsort 3% / remainder 84%.
+
+**Successor lever (registered in spirit, needs a bar before code):**
+narrow the walk's WORKING arrays — `sw` is (M,3) int64 holding 28-bit
+hand masks (int32 fits exactly), `sworld` int64 for world indices
+≤256. ~16 B/slot less transient churn ≈ ~9 GiB at wedge scale,
+attacking the measured 2× pressure multiplier where it lives, and
+"bytes-per-eval down" is the north star's second axis. Stored waves
+narrowed in 18n already; this is the transient side. Dtype-promotion
+traps (numpy silently upcasting mixed int32/int64 expressions) make
+this a parity-gated structural change — workflow/subagent sized.

--- a/wiki/topics/perf-log.md
+++ b/wiki/topics/perf-log.md
@@ -404,3 +404,81 @@ convergence beats the cap) but *gap_capped* here at 149 s, because the
 faster engine reached a budget checkpoint first. Wall stops are
 timing-dependent (exactly why engine="loop" refuses `wall_budget_s`);
 the cascade carries the root to rung 1 unharmed.
+
+## 2026-07-18m — the Fable consult: stop walking — in-struct gap pricing (16×), the duplicate value, and three honest kills
+
+A fable subagent was consulted for next levers after 18l. Its structural
+finding beats everything the 18k issue listed: **gap pricing re-walked a
+tree that was already resident** — `measure()` exported the profile and
+`impl.br_solve` rebuilt the whole subgame per seat per measurement,
+paying the stochastic-profile blowup (18b: p50 526×) each time. Exact
+single-seat BR needs only a forward-reach + backward-argmax pass over
+the `_WaveStruct` the solve already holds. The fix is not to fuse the
+walk; it is to stop walking.
+
+**Landed (L1)** — `_wave_br` in cfr.py: counterfactual reach forward
+(hero edges at prob 1), backward with per-iset signed argmax at hero
+info sets (chosen move's per-world child values propagate unweighted),
+sigma-weighted expectation elsewhere. Ties → lowest move
+(value-identical); zero-reach isets contribute zero (same exactness
+argument as pinned support pruning). Export moved to the final stop.
+The wave/fused engines share it; **engine="loop" keeps impl.br_solve
+pricing as the standing oracle**, plus new gate P4 (in-struct gap ==
+br_solve gap on the exported profile, ≤1e-9 — measured 0.0e+00 on
+toys/pins, 3.6e-15 on the anchor). Anchor trace reproduces the banked
+ledger row at 2.2e-07 (within its 1e-6 rounding license); fused-vs-wave
+stays bitwise (shared pricing path). **P8 (registered: ≥10× on the
+anchor's 26.4 s br bucket): PASS at 16×** — br 26.5 → 1.65 s; anchor
+solve wall 41.0 → **15.9 s** (88.6 at session start: **5.6× today**).
+
+**Landed (L2)** — the reference value was computed twice: measured on
+ALL 200 banked rows, `value_selfplay == cfr_reference_value` with max
+delta exactly 0.0 (both are exact expectations of the same profile over
+the same worlds). refsweep now uses `res.value`; `profile_value`
+survives as a deterministic 1-in-20 audit that raises on >1e-9 (P9:
+audit never fires). Non-CFR phase walls (enumerate/σ-filter/compile/
+walt-BR) — 6% of the 18j fleet spend and previously un-instrumented
+inside `wall_s` — now land in every ledger row as `phase_s` (law 6).
+
+**P10 sweep** (same 20 stratified roots, 5 workers, rung-0 ladder):
+20/20 rows in **120 s elapsed** (was 360 s at 18l) — **19/20 converged
+at rung 0** (was 17/20; 555039 and 555156 now beat the 90 s cap instead
+of laddering). Same-seed worker-time: banked 2,898 → 18l 808 → **235 s
+(12.3× vs banked, 3.43× vs 18l)** on the both-converged subset; on the
+full-ladder accounting (19 seeds, banked needed rung-1 re-solves) it is
+**277 → 19.5 worker-s per usable eval = 14.2×**. Old contention victims
+fell 35× (555008: 954 → 27 s). Sample-naive velocity 570/h is
+tail-bound (64% utilization on a 20-root batch); fleet-equivalent
+projection: rung-0 **~2,000–2,800 evals/hour** (was 224) — P10 (≥1,600)
+PASS by projection, to be banked at the next full production sweep.
+
+**Kills, all measured or theory-checked (append-only honesty):**
+- **BR-walk numba fusion** (my queued lever): consumer vanished under
+  L1; the stochastic walk is argsort/unique-bound (~200 ns/node vs the
+  fused iterate's ~10 ns/edge) and only #77-class offline work still
+  pays it.
+- **Regret-based gap bounds**: the 2p folk bound (exploitability ≤ Σ
+  avg regrets) needs utility linear in ONE opponent's strategy; with
+  three opponents the average of products ≠ product of averages, so
+  seat u's average regret does NOT bound its BR gain vs the average
+  profile. Dead on theory, and L1 removed the motivation.
+- **Seat-subset early exit**: only helps failing measurements; a capped
+  row's final_gap must price all four seats anyway.
+- **L4 (more workers)**: killed by its own gate — monster-shard peak
+  RSS is 16.3 GiB (L1 actually lowered it from 18l's 21.2: the mixed-BR
+  walk was itself a big allocator) on the 48 GiB box; 5 workers is the
+  right rung-0 default. GIB_PER_32M stays.
+
+**Queued, not built** (Fable's L3/L5/L6): adaptive gap cadence
+(measure every 5–10 iters, stop at first crossing — pricing is now
+~0.4 s so the optimum inverts; worth ~25% of iterate); exact CFR state
+checkpoint for rung survivors — serialize (sig_c, reg_c, avg_c, it) and
+RESUME, bitwise-equal to an uncapped run, NOT profile warm-start (RM+
+with zero regrets resets toward uniform; regret transfer is a numerics
+license we don't need); numba `expand_full_width` — post-L1 anatomy
+says build is now the top bucket (166 s of 386 on the P10 sweep = 43%,
+iterate 38%, br 9%) but it is the shared parity surface under
+compile_sigma/br_solve/CFR — a much bigger license, lever-after-next.
+
+Amdahl after 18m: **build 43% / iterate 38% / export+br+value ~13% /
+oracle phases ~6%** — the referee is no longer priced by its pricing.

--- a/wiki/topics/perf-log.md
+++ b/wiki/topics/perf-log.md
@@ -701,10 +701,48 @@ was 45% of fleet wall. Fleet iterate bucket 207.6 → **101.8 worker-s
 banked)**; full-cascade root-wall-cum 578 → 473 s; projected rung-0
 velocity **~3,400–4,650 evals/hour** (was ~2,700–3,700).
 
-Amdahl after 18q (rung-0 fleet, t4): **build 48% / iterate 23% / br
+Amdahl after 19a (rung-0 fleet, t4): **build 48% / iterate 23% / br
 17% / export 10%** — the wheel turns back to build, and the two big
 build levers are known: run_engine's own gathers (the shared-surface
 license, 18n's lever-after-next) and the per-root fixed overheads that
 kept P11 honest (subgame build, jit-warm, worlds). Cap verdicts kept:
 threads on the solo rung-2 wedge are marginal (234–250 s at any
 count); σ-branch gather kernel stays capped at 3–4% fleet (18p).
+
+## 2026-07-19b — big-root build anatomy: the fleet build bucket is half contention; PB8's counting sort built, measured, deleted
+
+The P11 lesson applied to the anatomy itself: fleet build is dominated
+by big-TREE roots (555046: 29.8 s build in the t4 sweep for 4.1 s of
+iterate — it converges in 10 iters; 555156: 21.2 s), so the anchor is
+the wrong specimen. Priors registered on 555046 (117.8M slots, solo,
+threads=4): PB6 walk ≥45% of build — **CONFIRMED at 47%** (5.6 s);
+PB7 _build_fused ≤15% — **REFUTED at 17%** (2.0 s). Post-walk 37%.
+
+**The headline is neither bucket: 555046 solo builds in 11.9 s vs
+29.8 s inside the 5-worker sweep — the fleet build bucket is ~2.5×
+DRAM contention, not code.** (Law 3 and the law-8 corollary, measured
+again at rung 0: bandwidth-bound monsters barely parallelize. The
+refsweep already staggers monsters; a width-per-stratum schedule —
+solve the 2–3 big-tree roots at low width first, then flood the small
+tail at 5 workers — is the cheapest untaken build lever and needs no
+kernel work at all.)
+
+**PB8 registered and REFUTED same-session** (fp32 precedent: knob
+built, measured, deleted). Hypothesis: P13's perm-building argsorts
+tax big-root builds; a numba stable counting sort (O(n), provably
+identical perms) would cut ≥0.5 s of 555046's _build_fused. Measured:
+2.02 → 1.92 s — **0.1 s; numpy's stable int32 argsort is already a
+radix sort.** This is PB2's np.unique lesson RE-LEARNED (18n: "the
+argsort fear is stale knowledge") — twice now: **comparison-sort
+intuitions do not price numpy 2.x integer sorts; measure before
+building around them.** The counting-sort kernel was deleted; the
+perm-equality gate script stays in scratch as the receipt
+(perm_gate.py, PASS before deletion).
+
+Next levers for the build bucket, in cheapness order: (1) the
+width-per-stratum sweep schedule (pure scheduling, prior ~1.3–1.6×
+on the fleet build bucket via decontention); (2) run_engine gather
+fusion (0.87 s/anchor scale, shared-surface license); (3) _build_fused
+base layout (1.9 s on the big root — casts and seat loops, threadable
+behind the same P13 structure). None registered yet with bars — the
+successor should anatomy (1) first since it is free.

--- a/wiki/topics/perf.md
+++ b/wiki/topics/perf.md
@@ -129,9 +129,10 @@ issues for perf items per 2026-07-18 directive).
   ([[perf-log]] 18o — exact by construction, gate P5). Same-seed paired
   sweep at refsweep's threads=4 default: **23.7× worker-time per
   usable eval vs banked** (11.7 worker-s), projected rung-0
-  ~3,400–4,650 evals/hour (was 224); full-line model ~700 evals/hour
-  (~37× banked) with the two rung-2 wedges as ~half the modeled wall —
-  the wedge is 589.6M slots and 2× memory-pressured, both measured
+  ~3,400–4,650 evals/hour (was 224); full-line model v2 ~960
+  evals/hour (~52× banked) with ONE rung-2 wedge as ~30% of the
+  modeled wall (555212 dissolved to rung 0 at 72 s, [[perf-log]] 19g)
+  — the wedge is 589.6M slots and 2× memory-pressured, both measured
   ([[perf-log]] 19e); the pressure term is untouchable from the
   transient side — int32 walk working arrays landed as a 1.16× walk /
   1.07× build bandwidth win with ZERO churn effect, so the remaining

--- a/wiki/topics/perf.md
+++ b/wiki/topics/perf.md
@@ -132,7 +132,13 @@ issues for perf items per 2026-07-18 directive).
   ~3,400–4,650 evals/hour (was 224); **full line MEASURED
   2026-07-19: 200/200 converged in 17.0 min = 706 evals/hour, 38.1×
   banked, 14.8 worker-s/eval** ([[perf-log]] 19h; in-fleet rung mix
-  197/2/1, the models retired) — the one wedge is 589.6M slots and
+  197/2/1, the models retired), re-measured at **727 evals/hour
+  (16.5 min)** after refsweep's static snake shards became one
+  pull-based biggest-first claim queue — rung-0 pools balance to ±1 s,
+  h2's pool 1.245×, line 1.03× quoted flat, per-seed reference values
+  bit-identical; precision cost ordering (banked walls) measured
+  WORSE than sigma order, monster co-residency contention
+  ([[perf-log]] 19i) — the one wedge is 589.6M slots and
   2× memory-pressured, both measured
   ([[perf-log]] 19e); the pressure term is untouchable from the
   transient side — int32 walk working arrays landed as a 1.16× walk /

--- a/wiki/topics/perf.md
+++ b/wiki/topics/perf.md
@@ -106,20 +106,23 @@ issues for perf items per 2026-07-18 directive).
   deterministic BR re-solves at **0.9 ms p50** (45× the net wavefront;
   24.7 ns/node; payoff AND belief weights swappable free); H5-cap512 BR
   p50 3.5 ms. CFR+ reference profiles: gap ≤0.05 pts in ~40 iterations
-  (scale-invariant in worlds so far); cap-256 anchor solve **15.9 s**
-  after the fused iterate + in-struct gap pricing ([[perf-log]] 18l/18m,
-  #82: numba edge kernels + forced-slot compression, 7.1× iterate,
-  bitwise; then exact BR priced on the resident wave structure, 16× —
-  "the fix is not to fuse the walk; it is to stop walking"). P6
-  confirmed, P7/fp32 refuted-and-deleted, P8 16×, P9/P10 green; the
+  (scale-invariant in worlds so far); cap-256 anchor solve **13.0 s**
+  after the fused iterate + in-struct gap pricing + resident-build
+  levers ([[perf-log]] 18l/18m/18n, #82: numba edge kernels +
+  forced-slot compression, 7.1× iterate, bitwise; exact BR priced on
+  the resident wave structure, 16×; then the build stopped re-deriving
+  what the walk already held — pslot/actor resident + numba move fill,
+  2.36× build. "The fix is not to fuse the walk; it is to stop
+  walking"). P6 confirmed, P7/fp32 refuted-and-deleted, P8 16×, P9/P10
+  green, P11 narrowly refuted (1.21× vs its 1.25× bar); the
   regret-bound gap shortcut is dead on theory (the 2p folk bound needs
-  utility linear in one opponent). Same-seed paired sweep: **14.2×
-  worker-time per usable eval**, projected rung-0 ~2,000–2,800
-  evals/hour (was 224). Build is now the top bucket (43%) — numba
-  expand_full_width is the registered lever-after-next. The anchor's
+  utility linear in one opponent). Same-seed paired sweep: **16.9×
+  worker-time per usable eval vs banked**, projected rung-0
+  ~2,400–3,300 evals/hour (was 224). Iterate is back on top (50%) —
+  adaptive gap cadence (L3) is the registered next lever. The anchor's
   full reference line is built (`hoyt/reference_h4_v1_cap256.jsonl`,
   200/200 at gap ≤0.05) via the `hoyt/refsweep.py` cascade — law 8's
-  shape ([[perf-log]] 18h–m).
+  shape ([[perf-log]] 18h–n).
 - **Burl inference**: no confirmed continuous-batching win; production
   picks are turn-aware token budgets + PLE-safe Q4 quant (memory, not
   wall). The sprint is dormant; resume via [[perf-sprint]].

--- a/wiki/topics/perf.md
+++ b/wiki/topics/perf.md
@@ -106,13 +106,16 @@ issues for perf items per 2026-07-18 directive).
   deterministic BR re-solves at **0.9 ms p50** (45× the net wavefront;
   24.7 ns/node; payoff AND belief weights swappable free); H5-cap512 BR
   p50 3.5 ms. CFR+ reference profiles: gap ≤0.05 pts in ~40 iterations
-  (scale-invariant in worlds so far); cap-256 median root **~92 s / 6.7
-  GiB peak** after the columnar-profile day ([[perf-log]] 18g: export
-  14×, mixed-profile BR 1.5×, RSS 1.6× — the hog was python objects, not
-  arrays; iterate is now 62% of wall and bandwidth-bound). The anchor's
-  full reference line is built (`hoyt/reference_h4_v1_cap256.jsonl`,
-  200/200 at gap ≤0.05) via the `hoyt/refsweep.py` cascade — law 8's
-  shape, rung-0 velocity 224 evals/hour ([[perf-log]] 18h–j).
+  (scale-invariant in worlds so far); cap-256 anchor solve **~41 s**
+  after the fused iterate ([[perf-log]] 18l, #82: numba edge kernels +
+  forced-slot compression, **7.1× iterate**, bitwise vs the numpy
+  mirror; P6 confirmed 3.13× from compression alone, P7/fp32 refuted
+  and deleted — gather-latency-bound, not float-bound). Exact-BR gap
+  pricing is now 65–71% of solve wall (the next lever, law 7). The
+  anchor's full reference line is built
+  (`hoyt/reference_h4_v1_cap256.jsonl`, 200/200 at gap ≤0.05) via the
+  `hoyt/refsweep.py` cascade — law 8's shape, rung-0 velocity 224
+  evals/hour pre-kernel ([[perf-log]] 18h–j; 18l for post-kernel).
 - **Burl inference**: no confirmed continuous-batching win; production
   picks are turn-aware token budgets + PLE-safe Q4 quant (memory, not
   wall). The sprint is dormant; resume via [[perf-sprint]].

--- a/wiki/topics/perf.md
+++ b/wiki/topics/perf.md
@@ -106,7 +106,7 @@ issues for perf items per 2026-07-18 directive).
   deterministic BR re-solves at **0.9 ms p50** (45× the net wavefront;
   24.7 ns/node; payoff AND belief weights swappable free); H5-cap512 BR
   p50 3.5 ms. CFR+ reference profiles: gap ≤0.05 pts in ~40 iterations
-  (scale-invariant in worlds so far); cap-256 anchor solve **13.0 s**
+  (scale-invariant in worlds so far); cap-256 anchor solve **12.6 s**
   after the fused iterate + in-struct gap pricing + resident-build
   levers ([[perf-log]] 18l/18m/18n, #82: numba edge kernels +
   forced-slot compression, 7.1× iterate, bitwise; exact BR priced on

--- a/wiki/topics/perf.md
+++ b/wiki/topics/perf.md
@@ -132,7 +132,10 @@ issues for perf items per 2026-07-18 directive).
   ~3,400–4,650 evals/hour (was 224); full-line model ~700 evals/hour
   (~37× banked) with the two rung-2 wedges as ~half the modeled wall —
   the wedge is 589.6M slots and 2× memory-pressured, both measured
-  ([[perf-log]] 19e). The anchor's
+  ([[perf-log]] 19e); the pressure term is untouchable from the
+  transient side — int32 walk working arrays landed as a 1.16× walk /
+  1.07× build bandwidth win with ZERO churn effect, so the remaining
+  pressure lever is resident footprint ([[perf-log]] 19f). The anchor's
   full reference line is built (`hoyt/reference_h4_v1_cap256.jsonl`,
   200/200 at gap ≤0.05) via the `hoyt/refsweep.py` cascade — law 8's
   shape ([[perf-log]] 18h–19a).

--- a/wiki/topics/perf.md
+++ b/wiki/topics/perf.md
@@ -83,7 +83,13 @@ issues for perf items per 2026-07-18 directive).
    and a budget ladder deepens only the shrinking survivor tail. Corollary
    measured twice in one day: **bandwidth-bound monsters barely
    parallelize** (8-wide big-root solves aggregate to ≈1.3× ONE quiet
-   worker) — tune width per rung, never flat. 42's cap verdict is
+   worker) — tune width per rung, never flat. Refined by the zero-diff
+   width experiment ([[perf-log]] 19c): decontention is real (1.42×
+   per-root at width 3 vs 5) yet **width beats decontention wherever
+   decontention < width ratio** — on the M5 Max that is every stratum
+   measured, so throughput (Little's law) keeps the flood and
+   per-eval worker-seconds stays a pricing tool, not the objective.
+   42's cap verdict is
    *quantified* (the exactly-priced gap at stop), so capped rows are
    usable references, and the hard stratum is predictable a priori from
    belief width. Registered metric ([[perf-log]] 18h): **H4 evals per

--- a/wiki/topics/perf.md
+++ b/wiki/topics/perf.md
@@ -106,16 +106,20 @@ issues for perf items per 2026-07-18 directive).
   deterministic BR re-solves at **0.9 ms p50** (45× the net wavefront;
   24.7 ns/node; payoff AND belief weights swappable free); H5-cap512 BR
   p50 3.5 ms. CFR+ reference profiles: gap ≤0.05 pts in ~40 iterations
-  (scale-invariant in worlds so far); cap-256 anchor solve **~41 s**
-  after the fused iterate ([[perf-log]] 18l, #82: numba edge kernels +
-  forced-slot compression, **7.1× iterate**, bitwise vs the numpy
-  mirror; P6 confirmed 3.13× from compression alone, P7/fp32 refuted
-  and deleted — gather-latency-bound, not float-bound). Exact-BR gap
-  pricing is now 65–71% of solve wall (the next lever, law 7). The
-  anchor's full reference line is built
-  (`hoyt/reference_h4_v1_cap256.jsonl`, 200/200 at gap ≤0.05) via the
-  `hoyt/refsweep.py` cascade — law 8's shape, rung-0 velocity 224
-  evals/hour pre-kernel ([[perf-log]] 18h–j; 18l for post-kernel).
+  (scale-invariant in worlds so far); cap-256 anchor solve **15.9 s**
+  after the fused iterate + in-struct gap pricing ([[perf-log]] 18l/18m,
+  #82: numba edge kernels + forced-slot compression, 7.1× iterate,
+  bitwise; then exact BR priced on the resident wave structure, 16× —
+  "the fix is not to fuse the walk; it is to stop walking"). P6
+  confirmed, P7/fp32 refuted-and-deleted, P8 16×, P9/P10 green; the
+  regret-bound gap shortcut is dead on theory (the 2p folk bound needs
+  utility linear in one opponent). Same-seed paired sweep: **14.2×
+  worker-time per usable eval**, projected rung-0 ~2,000–2,800
+  evals/hour (was 224). Build is now the top bucket (43%) — numba
+  expand_full_width is the registered lever-after-next. The anchor's
+  full reference line is built (`hoyt/reference_h4_v1_cap256.jsonl`,
+  200/200 at gap ≤0.05) via the `hoyt/refsweep.py` cascade — law 8's
+  shape ([[perf-log]] 18h–m).
 - **Burl inference**: no confirmed continuous-batching win; production
   picks are turn-aware token budgets + PLE-safe Q4 quant (memory, not
   wall). The sprint is dormant; resume via [[perf-sprint]].

--- a/wiki/topics/perf.md
+++ b/wiki/topics/perf.md
@@ -153,7 +153,8 @@ issues for perf items per 2026-07-18 directive).
 
 ## Links
 
-[[perf-on-the-table]] · [[walt-spec]] · [[walt]] · [[perf-sprint]] ·
+[[hoyt-perf-primer]] (the campaign's shorthand decoded for cold
+readers) · [[perf-on-the-table]] · [[walt-spec]] · [[walt]] · [[perf-sprint]] ·
 [[perf-sprint-levers]] · [[perf-sprint-traps]] ·
 [[continuous-batching-dispatcher-design]] · [[batch-throughput-bench]] ·
 [[batched-harvest-resilience]] · [[forge]] · [[jud]]

--- a/wiki/topics/perf.md
+++ b/wiki/topics/perf.md
@@ -129,10 +129,11 @@ issues for perf items per 2026-07-18 directive).
   ([[perf-log]] 18o — exact by construction, gate P5). Same-seed paired
   sweep at refsweep's threads=4 default: **23.7× worker-time per
   usable eval vs banked** (11.7 worker-s), projected rung-0
-  ~3,400–4,650 evals/hour (was 224); full-line model v2 ~960
-  evals/hour (~52× banked) with ONE rung-2 wedge as ~30% of the
-  modeled wall (555212 dissolved to rung 0 at 72 s, [[perf-log]] 19g)
-  — the wedge is 589.6M slots and 2× memory-pressured, both measured
+  ~3,400–4,650 evals/hour (was 224); **full line MEASURED
+  2026-07-19: 200/200 converged in 17.0 min = 706 evals/hour, 38.1×
+  banked, 14.8 worker-s/eval** ([[perf-log]] 19h; in-fleet rung mix
+  197/2/1, the models retired) — the one wedge is 589.6M slots and
+  2× memory-pressured, both measured
   ([[perf-log]] 19e); the pressure term is untouchable from the
   transient side — int32 walk working arrays landed as a 1.16× walk /
   1.07× build bandwidth win with ZERO churn effect, so the remaining

--- a/wiki/topics/perf.md
+++ b/wiki/topics/perf.md
@@ -129,7 +129,10 @@ issues for perf items per 2026-07-18 directive).
   ([[perf-log]] 18o — exact by construction, gate P5). Same-seed paired
   sweep at refsweep's threads=4 default: **23.7× worker-time per
   usable eval vs banked** (11.7 worker-s), projected rung-0
-  ~3,400–4,650 evals/hour (was 224). The anchor's
+  ~3,400–4,650 evals/hour (was 224); full-line model ~700 evals/hour
+  (~37× banked) with the two rung-2 wedges as ~half the modeled wall —
+  the wedge is 589.6M slots and 2× memory-pressured, both measured
+  ([[perf-log]] 19e). The anchor's
   full reference line is built (`hoyt/reference_h4_v1_cap256.jsonl`,
   200/200 at gap ≤0.05) via the `hoyt/refsweep.py` cascade — law 8's
   shape ([[perf-log]] 18h–19a).

--- a/wiki/topics/perf.md
+++ b/wiki/topics/perf.md
@@ -116,13 +116,14 @@ issues for perf items per 2026-07-18 directive).
   walking"). P6 confirmed, P7/fp32 refuted-and-deleted, P8 16×, P9/P10
   green, P11 narrowly refuted (1.21× vs its 1.25× bar); the
   regret-bound gap shortcut is dead on theory (the 2p folk bound needs
-  utility linear in one opponent). Same-seed paired sweep: **16.9×
-  worker-time per usable eval vs banked**, projected rung-0
-  ~2,400–3,300 evals/hour (was 224). Iterate is back on top (50%) —
-  adaptive gap cadence (L3) is the registered next lever. The anchor's
+  utility linear in one opponent); gap_exit prices intermediate
+  measurements one seat at a time and exits at the first crossing
+  ([[perf-log]] 18o — exact by construction, gate P5). Same-seed paired
+  sweep: **18.9× worker-time per usable eval vs banked**, projected
+  rung-0 ~2,700–3,700 evals/hour (was 224). The anchor's
   full reference line is built (`hoyt/reference_h4_v1_cap256.jsonl`,
   200/200 at gap ≤0.05) via the `hoyt/refsweep.py` cascade — law 8's
-  shape ([[perf-log]] 18h–n).
+  shape ([[perf-log]] 18h–o).
 - **Burl inference**: no confirmed continuous-batching win; production
   picks are turn-aware token budgets + PLE-safe Q4 quant (memory, not
   wall). The sprint is dormant; resume via [[perf-sprint]].

--- a/wiki/topics/perf.md
+++ b/wiki/topics/perf.md
@@ -2,7 +2,7 @@
 title: Perf — the measured laws of making this project fast
 kind: topic
 first_seen: 2026-07-18
-last_updated: 2026-07-18
+last_updated: 2026-07-19
 status: active
 ---
 
@@ -106,24 +106,27 @@ issues for perf items per 2026-07-18 directive).
   deterministic BR re-solves at **0.9 ms p50** (45× the net wavefront;
   24.7 ns/node; payoff AND belief weights swappable free); H5-cap512 BR
   p50 3.5 ms. CFR+ reference profiles: gap ≤0.05 pts in ~40 iterations
-  (scale-invariant in worlds so far); cap-256 anchor solve **12.6 s**
-  after the fused iterate + in-struct gap pricing + resident-build
-  levers ([[perf-log]] 18l/18m/18n, #82: numba edge kernels +
-  forced-slot compression, 7.1× iterate, bitwise; exact BR priced on
-  the resident wave structure, 16×; then the build stopped re-deriving
-  what the walk already held — pslot/actor resident + numba move fill,
-  2.36× build. "The fix is not to fuse the walk; it is to stop
-  walking"). P6 confirmed, P7/fp32 refuted-and-deleted, P8 16×, P9/P10
-  green, P11 narrowly refuted (1.21× vs its 1.25× bar); the
+  (scale-invariant in worlds so far); cap-256 anchor solve **7.2 s**
+  after the fused iterate + in-struct gap pricing + resident-build +
+  threaded-iterate levers ([[perf-log]] 18l/18m/18n/19a, #82: numba
+  edge kernels + forced-slot compression, 7.1× iterate, bitwise; exact
+  BR priced on the resident wave structure, 16×; the build stopped
+  re-deriving what the walk already held — pslot/actor resident +
+  numba move fill, 2.36× build; then the iterate went parallel while
+  staying bitwise — build-time stable argsorts give every thread a
+  disjoint output range with bincount-order folds, 2.67–3.12× iterate
+  at 4–8 threads). P6 confirmed, P7/fp32 refuted-and-deleted, P8 16×,
+  P9/P10 green, P11/P14/P16 narrowly refuted (quoted flat); the
   regret-bound gap shortcut is dead on theory (the 2p folk bound needs
   utility linear in one opponent); gap_exit prices intermediate
   measurements one seat at a time and exits at the first crossing
   ([[perf-log]] 18o — exact by construction, gate P5). Same-seed paired
-  sweep: **18.9× worker-time per usable eval vs banked**, projected
-  rung-0 ~2,700–3,700 evals/hour (was 224). The anchor's
+  sweep at refsweep's threads=4 default: **23.7× worker-time per
+  usable eval vs banked** (11.7 worker-s), projected rung-0
+  ~3,400–4,650 evals/hour (was 224). The anchor's
   full reference line is built (`hoyt/reference_h4_v1_cap256.jsonl`,
   200/200 at gap ≤0.05) via the `hoyt/refsweep.py` cascade — law 8's
-  shape ([[perf-log]] 18h–o).
+  shape ([[perf-log]] 18h–19a).
 - **Burl inference**: no confirmed continuous-batching win; production
   picks are turn-aware token budgets + PLE-safe Q4 quant (memory, not
   wall). The sprint is dormant; resume via [[perf-sprint]].


### PR DESCRIPTION
Stacks on #81 (worktree-perf-day). The #82 kernel: every fp64 result is **bit-identical** to the numpy wave engine — traces, values, gaps, and exported profiles — on toys, pins, and the 555006 cap-256 anchor.

## What landed
- **`hoyt/iterkernel.py` + `engine="fused"` (new cfr_solve default)**: single-threaded numba edge kernels that replicate numpy's accumulation order exactly (strict IEEE, no FMA) — int32 indices, int8 edge seats, forced edges skip the σ gather (`cgid = −1`), pr/pm/pu temporaries never exist.
- **Forced-slot compression, proven exact**: forced isets are inert in RM+ (σ ≡ 1.0, regret ≡ 0 *exactly*), so reg/avg/cf/xI shrink 18.8M → 5.6M slots, stable-sorted by seat so each seat's update is a contiguous slice. The wave engine stays as the pinned pure-numpy mirror, loop as the recursive oracle (parity gate P3 added).

## Measured (perf-log 18l; quiet box, triad detector 39–46 GB/s throughout)
- **Anatomy inverted the 18k picture**: the RM+ update block was 72% of iterate, not the gather chains — compression aimed at the bigger half.
- Anchor iterate **1.39 → 0.196 s/iter (7.1×)**; **P6 CONFIRMED**: compression alone 3.13× (prior ≥2×). Anchor solve wall 88.6 → 41.0 s; stratified paired trio 1.91–2.37×, bitwise PASS everywhere.
- **P7 REFUTED and the fp32 lane deleted**: gap drift 2.59e-3 (> 1e-3 bar) AND zero throughput win — the fused loops are gather-latency-bound, not float-bandwidth-bound.
- **Paired production sweep** (20 stratified roots, 5 workers, rung-0 ladder): same-seed same-rung vs the 18j ledger, **2,898 → 808 worker-s (3.59×)**; the banked contention victims fell 9–10× (law-8 corollary in reverse — fused workers no longer saturate DRAM). Projected rung-0 velocity **~800 H4 evals/hour** (was 224).
- **Amdahl (law 7)**: exact-BR gap pricing is now 65–71% of solve wall — the next lever is the mixed-profile BR walk / br_every cadence, not more iterate work.

Gates: P1/P2/P3 parity 0.0e+00, 53 pytest green, wiki lint 531 pages clean. numba is now a runtime dep of the default engine (CONTRACTS.md updated; wave/loop stay numba-free).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LFdT65b5KdfkNBZsBTzMWf