### PR TITLE
hoyt: implement bounded full-Metal H5/H6 lane

### DIFF
--- a/hoyt/CONTRACTS.md
+++ b/hoyt/CONTRACTS.md
@@ -68,6 +68,14 @@ the frozen-root stable eval, H5/H6 horizon pushes.
   primitive: exact gap minus independently evaluated sampled-BR upper bound.
   Production convergence requires candidate uncertainty plus this calibrated
   optimization-shortfall bound; otherwise the verdict is `unresolved`.
+- `HoytPlay` (`hoyt/play.py`) is the experimental Arena-shaped player
+  consumer. It projects each `ZebGameState` to an `EndgameRoot` containing
+  only the acting seat's hand and public state, runs a fresh `SampledCFR`, and
+  returns a legal zeb slot. Its default payoff is `payoff_make(bid)`; `points`
+  is optional. It may only enter at H5/H6, schedules batch members serially,
+  and exposes fixed-candidate action intervals without claiming calibrated
+  optimization shortfall. The resumable table stores the full deal under
+  `scratch/` solely for the zeb referee and never renders hidden hands.
 
 ## Gates
 
@@ -91,6 +99,10 @@ the frozen-root stable eval, H5/H6 horizon pushes.
   band and root moves agree; capacity fails closed; four-seat sampled CFR
   matches exact H2 value, visits all actors, and frozen-policy forks reset only
   their updating seat. Candidate policies round-trip as artifacts.
+- **P1 playable boundary**: changing the three non-acting hidden holdings
+  leaves `root_from_state` identical; session save/load is exact; the renderer
+  shows only public history plus the human hand; forced moves do not construct
+  a solver; complete H5/H6 continuations remain zeb-legal.
 
 ## Honesty line (registered)
 
@@ -107,9 +119,10 @@ team-pair deviation out of scope.
   `walt/tests/test_cfr_*.py`. `reference.py` is a tiny pure-python
   implementation of THIS interface for toys only (correctness mirror, no
   perf goals) so the CFR lane never blocks on the kernel lane.
-- Full-metal lane: `hoyt/{metalkernel,worldsample,sampled_br,metalcal}.py` and
-  `hoyt/tests/test_{cfr_metal,worldsample,sampled_br}.py`. MLX is required for
-  these surfaces (`burl/requirements-mlx.txt`); exact CPU defaults do not
+- Full-metal lane:
+  `hoyt/{metalkernel,worldsample,sampled_br,metalcal,play}.py` and
+  `hoyt/tests/test_{cfr_metal,worldsample,sampled_br,play}.py`. MLX is required
+  for these surfaces (`burl/requirements-mlx.txt`); exact CPU defaults do not
   import it eagerly.
 - Neither lane edits existing walt modules, this file, or the other lane's
   files. Python via `/Users/jason/code/mk5-main/.venv/bin/python -u` from

--- a/hoyt/CONTRACTS.md
+++ b/hoyt/CONTRACTS.md
@@ -1,5 +1,9 @@
 # hoyt — the net-free kernel (frozen interface, 2026-07-18)
 
+2026-07-21 additive extension: [[full-metal-hoyt]] preserves every exact CPU
+surface below and adds explicitly approximate Metal/sampling surfaces. Nothing
+approximate is allowed to masquerade as `br_solve` or the fp64 default.
+
 Program registration: wiki/topics/perf-log.md entry 2026-07-18a. The kernel
 is the zero-torch solve substrate: bitboard hands, LUT tricks (from
 `walt.tables`, never reimplemented), SoA waves. Consumers: exploitability
@@ -39,6 +43,31 @@ the frozen-root stable eval, H5/H6 horizon pushes.
   vs the average profile (measured with `br_solve`). Deterministic given
   seeds. Full-tree preferred; if H4 enumeration exceeds memory, STOP and
   escalate to the orchestrator before reaching for sampling variants.
+  `engine="metal"` is the additive float32 dense engine: its iterate and
+  in-structure gap passes are Metal-resident, while build/export remain on
+  host. It is accuracy-calibrated and never bit-parity claimed.
+- `WorldSampler.from_root(root)` exactly counts and samples physical hidden
+  deals without enumeration; `sample_metal` runs one DP sampler per Metal
+  thread. This samples the uniform physical-world distribution only.
+- `SampledCFR(root, payoff43, capacity=...)` is the experimental shared-table
+  four-seat external-sampling lane. It alternates updater seats, branches all
+  updater actions, samples one current-policy opponent action, and exports a
+  current regret-matched `SparsePolicy` candidate. The policy can be saved as
+  `.npz`; unseen information fingerprints use an explicit uniform fallback.
+- `SampledBR(...)` trains against uniform opponents or is created with
+  `SampledCFR.fork_best_response(seat)` to reset one seat while freezing the
+  other three. A `SampledBRResult` carries independent evaluation standard
+  errors plus bounded-payoff empirical-Bernstein radii, not an exact
+  `BRResult` and not by itself a gap upper bound.
+- `audit_sampled_gap(...)` trains four frozen-policy BR candidates. Without a
+  calibrated optimization-shortfall bound its upper gap is infinity and its
+  verdict cannot be `converged`. With one, candidate and shortfall miscoverage
+  budgets must be supplied separately and are union-bounded. All sparse tables
+  fail closed on capacity.
+- `metalcal.br_shortfall_upper` supplies the missing one-sided calibration
+  primitive: exact gap minus independently evaluated sampled-BR upper bound.
+  Production convergence requires candidate uncertainty plus this calibrated
+  optimization-shortfall bound; otherwise the verdict is `unresolved`.
 
 ## Gates
 
@@ -53,6 +82,15 @@ the frozen-root stable eval, H5/H6 horizon pushes.
   average → 0 as iters grow.
 - **K3 speed** (log to perf-log, priors P1/P3/P5 registered): fixture-suite
   BR ≤0.5 s total; report ns/node and rows/s equivalents.
+- **M1–M3 Metal**: MLX GPU availability; float32 dense value/gap/profile error
+  on calibration toys; finite-sample conformal value/gap/BR-shortfall math.
+- **W1–W3 sampling**: DP population count equals exact enumeration; host and
+  Metal draws are physical; empirical cell frequencies pass the registered
+  uniformity smoke.
+- **S1–S4 sampling**: exact H2/H3 BR values fall inside the registered smoke
+  band and root moves agree; capacity fails closed; four-seat sampled CFR
+  matches exact H2 value, visits all actors, and frozen-policy forks reset only
+  their updating seat. Candidate policies round-trip as artifacts.
 
 ## Honesty line (registered)
 
@@ -69,6 +107,10 @@ team-pair deviation out of scope.
   `walt/tests/test_cfr_*.py`. `reference.py` is a tiny pure-python
   implementation of THIS interface for toys only (correctness mirror, no
   perf goals) so the CFR lane never blocks on the kernel lane.
+- Full-metal lane: `hoyt/{metalkernel,worldsample,sampled_br,metalcal}.py` and
+  `hoyt/tests/test_{cfr_metal,worldsample,sampled_br}.py`. MLX is required for
+  these surfaces (`burl/requirements-mlx.txt`); exact CPU defaults do not
+  import it eagerly.
 - Neither lane edits existing walt modules, this file, or the other lane's
   files. Python via `/Users/jason/code/mk5-main/.venv/bin/python -u` from
   the worktree root. numba is a RUNTIME dependency since the fused iterate

--- a/hoyt/cfr.py
+++ b/hoyt/cfr.py
@@ -36,8 +36,13 @@ seats, per world); an info set's own-reach is constant across its worlds
 (its seat's past probabilities are pinned by the public path), which the
 implementation exploits.
 
-Three interchangeable iteration engines (identical math, parity-gated in
-hoyt/tests/test_cfr_parity.py):
+Four interchangeable iteration engines (the three fp64 lanes are
+parity-gated in hoyt/tests/test_cfr_parity.py; Metal is accuracy-calibrated):
+
+- engine="metal": custom Metal kernels over the fused segment layout. CFR+
+  iterate state stays on the GPU between explicit gap-audit boundaries and
+  uses float32 arithmetic. The CPU fp64 lane is its calibration oracle, not a
+  bit-replication target.
 
 - engine="fused" (default): numba edge kernels (hoyt/iterkernel.py) over
   the wave engine's structure, with native int32 indices, forced-edge
@@ -691,7 +696,8 @@ class _FusedLayout:
                  "rmu", "ru2", "v2", "par", "vseg", "cf_ju", "iso")
 
 
-def _build_fused(ws: _WaveStruct, sig0_full, par: bool = False) -> _FusedLayout:
+def _build_fused(ws: _WaveStruct, sig0_full, par: bool = False,
+                 cpu_buffers: bool = True, warm_jit: bool = True) -> _FusedLayout:
     fl = _FusedLayout()
     fl.par = par
     nleg_iset = np.diff(np.append(ws.off, ws.Lflat))
@@ -745,10 +751,13 @@ def _build_fused(ws: _WaveStruct, sig0_full, par: bool = False) -> _FusedLayout:
         fl.eseat8.append(e)
 
     fl.w0 = ws.w0
-    fl.rmu = [np.empty(s) for s in ws.S]
-    max_s = max(ws.S)
-    fl.ru2 = (np.empty(max_s), np.empty(max_s))
-    fl.v2 = (np.empty(max_s), np.empty(max_s))
+    if cpu_buffers:
+        fl.rmu = [np.empty(s) for s in ws.S]
+        max_s = max(ws.S)
+        fl.ru2 = (np.empty(max_s), np.empty(max_s))
+        fl.v2 = (np.empty(max_s), np.empty(max_s))
+    else:
+        fl.rmu = fl.ru2 = fl.v2 = None
 
     if par:
         # P13 threading structure: every parallel fold's grouping is built
@@ -790,27 +799,28 @@ def _build_fused(ws: _WaveStruct, sig0_full, par: bool = False) -> _FusedLayout:
             fl.iso[u] = np.searchsorted(
                 fl.c_isl_loc[sl], np.arange(niu + 1)).astype(np.int64)
 
-    # warm the jit on 1-edge dummies so compile/cache-load lands in the
-    # build timing bucket, not the first iteration's
-    from hoyt.iterkernel import bwd_edges, fwd_edges
-    z32, f32 = np.zeros(1, np.int32), np.full(1, -1, np.int32)
-    z8 = np.zeros(1, np.int8)
-    d = np.ones(1)
-    fwd_edges(z32, f32, z8, 0, d, d.copy(), d.copy(),
-              np.empty(1), np.empty(1))
-    bwd_edges(z32, f32, z8, 0, d, d.copy(), d.copy(),
-              np.empty(1), d.copy())
-    if par:
-        from hoyt.iterkernel import (bwd_v_map, bwd_v_seg, cf_seg,
-                                     fwd_edges_par, rm_update_seg)
-        z64 = np.zeros(2, np.int64)
-        fwd_edges_par(z32, f32, z8, 0, d, d.copy(), d.copy(),
-                      np.empty(1), np.empty(1))
-        bwd_v_map(z32, f32, d, d.copy(), np.empty(1))
-        bwd_v_seg(z64, z32, f32, d, d.copy(), np.empty(1))
-        cf_seg(z64, z32, z32, z32, d, d.copy(), np.empty(1))
-        rm_update_seg(z64, d.copy(), d.copy(), d.copy(), d.copy(),
-                      np.empty(0), d.copy(), 1, 1)
+    if warm_jit:
+        # warm on 1-edge dummies so compile/cache-load lands in build, not
+        # iteration. The Metal lane has separate JIT kernels and skips this.
+        from hoyt.iterkernel import bwd_edges, fwd_edges
+        z32, f32 = np.zeros(1, np.int32), np.full(1, -1, np.int32)
+        z8 = np.zeros(1, np.int8)
+        d = np.ones(1)
+        fwd_edges(z32, f32, z8, 0, d, d.copy(), d.copy(),
+                  np.empty(1), np.empty(1))
+        bwd_edges(z32, f32, z8, 0, d, d.copy(), d.copy(),
+                  np.empty(1), d.copy())
+        if par:
+            from hoyt.iterkernel import (bwd_v_map, bwd_v_seg, cf_seg,
+                                         fwd_edges_par, rm_update_seg)
+            z64 = np.zeros(2, np.int64)
+            fwd_edges_par(z32, f32, z8, 0, d, d.copy(), d.copy(),
+                          np.empty(1), np.empty(1))
+            bwd_v_map(z32, f32, d, d.copy(), np.empty(1))
+            bwd_v_seg(z64, z32, f32, d, d.copy(), np.empty(1))
+            cf_seg(z64, z32, z32, z32, d, d.copy(), np.empty(1))
+            rm_update_seg(z64, d.copy(), d.copy(), d.copy(), d.copy(),
+                          np.empty(0), d.copy(), 1, 1)
     return fl
 
 
@@ -933,7 +943,10 @@ def cfr_solve(subgame, payoff43, iters: int = 200, target_gap: float | None = No
         engine: "fused" (numba edge kernels + forced-slot-compressed
             updates, default), "wave" (the pure-numpy mirror; fp64 results
             are bitwise identical to fused), or "loop" (the original
-            recursive mirror, toy sizes only).
+            recursive mirror, toy sizes only). "metal" runs float32 CFR+
+            updates as custom Metal kernels and crosses to the host only at
+            requested gap-audit boundaries; its contract is calibrated error,
+            not fp64 bit replication.
         slot_budget: forwarded to the kernel walk (wave engine); None keeps
             the kernel default. A KernelMemoryError means chunk or cap —
             escalate, never sample.
@@ -985,9 +998,10 @@ def cfr_solve(subgame, payoff43, iters: int = 200, target_gap: float | None = No
     if payoff43.shape[0] != 43:
         raise ValueError("payoff43 must have 43 entries")
     pinned = {int(s): p for s, p in (pinned or {}).items()}
-    if engine not in ("fused", "wave", "loop"):
+    if engine not in ("fused", "wave", "loop", "metal"):
         raise ValueError(
-            f"engine must be 'fused', 'wave' or 'loop', got {engine!r}")
+            f"engine must be 'fused', 'wave', 'loop' or 'metal', "
+            f"got {engine!r}")
     if wall_budget_s is not None and engine == "loop":
         raise ValueError("wall_budget_s requires engine='fused' or 'wave' "
                          "(the loop engine is the frozen parity mirror; "
@@ -998,13 +1012,13 @@ def cfr_solve(subgame, payoff43, iters: int = 200, target_gap: float | None = No
                          "parity-pinned against the loop mirror)")
     if threads is not None and engine != "fused":
         raise ValueError("threads requires engine='fused' (the wave and "
-                         "loop mirrors are the pinned single-threaded "
-                         "parity references)")
-    if engine in ("fused", "wave"):
+                         "loop mirrors and calibrated Metal lane do not "
+                         "consume numba thread counts)")
+    if engine in ("fused", "wave", "metal"):
         return _solve_wave(subgame, payoff43, iters, target_gap, br_every,
                            impl, pinned, debug, slot_budget, wall_budget_s,
                            fused=(engine == "fused"), gap_exit=gap_exit,
-                           threads=threads)
+                           threads=threads, metal=(engine == "metal"))
     return _solve_loop(subgame, payoff43, iters, target_gap, br_every,
                        impl, pinned, debug)
 
@@ -1041,9 +1055,11 @@ def _avg_sig(sig, avg, slot_iset, nlegal_slot, n_isets, unpinned_mask):
 
 def _solve_wave(subgame, payoff43, iters, target_gap, br_every, impl,
                 pinned, debug, slot_budget, wall_budget_s=None,
-                fused=False, gap_exit=False, threads=None) -> CFRResult:
-    tm = {"build": 0.0, "iterate": 0.0, "export": 0.0, "br": 0.0,
-          "value": 0.0}
+                fused=False, gap_exit=False, threads=None,
+                metal=False) -> CFRResult:
+    tm = {"build": 0.0, "walk": 0.0, "layout": 0.0,
+          "device_setup": 0.0, "iterate": 0.0, "export": 0.0,
+          "br": 0.0, "value": 0.0}
     t0 = time.time()
     if fused and threads:
         # set before the build, not just before _build_fused: any numba
@@ -1055,7 +1071,8 @@ def _solve_wave(subgame, payoff43, iters, target_gap, br_every, impl,
     ws = _build_wave(subgame.root, subgame.worlds, subgame.weights, pinned,
                      slot_budget, debug,
                      bulk_export=hasattr(impl.StochasticProfile, "set_bulk"),
-                     kernels=fused)
+                     kernels=fused or metal)
+    tm["walk"] = time.time() - t0
 
     bid_team = int(subgame.root.bidder) % 2
     signs = {u: sign_of(u, bid_team) for u in range(4)}
@@ -1073,8 +1090,17 @@ def _solve_wave(subgame, payoff43, iters, target_gap, br_every, impl,
             slot_pinned |= (slot_seat == s)
     live_seats = [u for u in range(4) if u not in pinned]
 
-    if fused:
-        fl = _build_fused(ws, sig, par=bool(threads))
+    if fused or metal:
+        tl = time.time()
+        fl = _build_fused(ws, sig, par=bool(threads) or metal,
+                          cpu_buffers=not metal, warm_jit=not metal)
+        tm["layout"] = time.time() - tl
+    if metal:
+        from hoyt.metalkernel import MetalCFR
+        td = time.time()
+        metal_state = MetalCFR(ws, fl, payleaf, sig, live_seats)
+        tm["device_setup"] = time.time() - td
+    elif fused:
         sig_c = sig[fl.c_flat].copy()
         reg_c = np.zeros(fl.n_c)
         avg_c = np.zeros(fl.n_c)
@@ -1115,6 +1141,14 @@ def _solve_wave(subgame, payoff43, iters, target_gap, br_every, impl,
         # the first crossing. Convergence is only ever declared after ALL
         # live seats priced, so a stopping gap is always the exact full max;
         # the exit cannot change the stop iteration or the final result.
+        if metal:
+            # Full device-side average value + single-seat BR audit. The
+            # public profile crosses to the host once, after the stopping
+            # iteration; intermediate certificates transfer only scalars.
+            t1 = time.time()
+            vbar, gap = metal_state.measure(signs)
+            tm["br"] += time.time() - t1
+            return vbar, gap
         t1 = time.time()
         v0 = _wave_values(ws, asig, payleaf)
         vbar = float(ws.w0 @ v0) / ws.total_w
@@ -1137,11 +1171,13 @@ def _solve_wave(subgame, payoff43, iters, target_gap, br_every, impl,
     capped = False
     over = (lambda: time.time() - t0 > wall_budget_s) \
         if wall_budget_s is not None else (lambda: False)
-    if not fused:
+    if not fused and not metal:
         cf = np.empty(ws.Lflat)
         xI = np.empty(ws.n_isets)
 
     def averaged():
+        if metal:
+            return metal_state.average_numpy()
         if fused:
             return _avg_sig_fused(fl, avg_c, live_seats)
         return _avg_sig(sig, avg, ws.slot_iset, ws.nlegal_slot,
@@ -1149,7 +1185,9 @@ def _solve_wave(subgame, payoff43, iters, target_gap, br_every, impl,
 
     for it in range(1, iters + 1):
         t1 = time.time()
-        if fused:
+        if metal:
+            metal_state.round(signs, it)
+        elif fused:
             for u in live_seats:
                 cf_c[fl.c_soff[u]:fl.c_soff[u + 1]] = 0.0
                 xI_c[fl.c_isoff[u]:fl.c_isoff[u + 1]] = 0.0
@@ -1166,7 +1204,7 @@ def _solve_wave(subgame, payoff43, iters, target_gap, br_every, impl,
         tm["iterate"] += time.time() - t1
         budget_stop = over()
         if it % br_every == 0 or it == iters or budget_stop:
-            asig = averaged()
+            asig = None if metal else averaged()
             # a measurement that can end the solve WITHOUT convergence
             # (iters exhausted / wall budget) must price all seats — a
             # capped row's final_gap is a full 4-seat verdict
@@ -1184,6 +1222,8 @@ def _solve_wave(subgame, payoff43, iters, target_gap, br_every, impl,
                 # boundary check sees the expired budget and prices fully
 
     asig_f, vbar, gap = result
+    if metal:
+        asig_f = averaged()
     prof = export(asig_f)              # once, at the stop — not per measure
     dbg = None
     if debug:
@@ -1191,7 +1231,17 @@ def _solve_wave(subgame, payoff43, iters, target_gap, br_every, impl,
         isets = SimpleNamespace(
             off=ws.off, i_moves=ws.dbg["i_moves"], i_node=ws.dbg["i_node"],
             i_seat=ws.dbg["i_seat"], i_hand=ws.dbg["i_hand"])
-        if fused:
+        if metal:
+            state = metal_state.debug_numpy()
+            reg = np.zeros(ws.Lflat)
+            reg[fl.c_flat] = state["reg_c"].astype(np.float64)
+            avg = np.zeros(ws.Lflat)
+            avg[fl.c_flat] = state["avg_c"].astype(np.float64)
+            sig = fl.sig0_full.copy()
+            sig[fl.c_flat] = state["sig_c"].astype(np.float64)
+            dbg_extra = {"metal_peak_bytes": metal_state.peak_memory,
+                         "metal_dtype": "float32"}
+        elif fused:
             # scatter compressed state to full-slot space; forced slots
             # carry their exact invariants (reg 0.0, sig 1.0). avg differs
             # from the wave engine's on forced/unreached slots (dead weight
@@ -1202,8 +1252,11 @@ def _solve_wave(subgame, payoff43, iters, target_gap, br_every, impl,
             avg[fl.c_flat] = avg_c
             sig = fl.sig0_full.copy()
             sig[fl.c_flat] = sig_c
+            dbg_extra = {}
+        else:
+            dbg_extra = {}
         dbg = {"isets": isets, "reg": reg, "avg": avg, "avg_sig": asig,
-               "sig": sig, "n_isets": ws.n_isets}
+               "sig": sig, "n_isets": ws.n_isets, **dbg_extra}
     return CFRResult(profile=prof, trace=trace, gap=gap, value=vbar,
                      iters_run=it, capped=capped, timings=tm, debug=dbg)
 

--- a/hoyt/metalcal.py
+++ b/hoyt/metalcal.py
@@ -1,0 +1,196 @@
+"""Distribution-free calibration for the float32 Metal reference lane.
+
+The calibration and held-out ledgers must be disjoint paired runs of the same
+seeds under ``engine=fused`` and ``engine=metal``. The report turns observed
+absolute errors into finite-sample split-conformal upper bounds and verifies
+their coverage on the untouched holdout. It also reports convergence and
+root-argmax behavior, stratified by the CPU decision margin when available.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from pathlib import Path
+from statistics import NormalDist
+
+import numpy as np
+
+DEFAULT_COVERAGE = 0.95
+DEFAULT_GAP_TARGET = 0.05
+
+
+def conformal_upper(errors, coverage: float = DEFAULT_COVERAGE) -> float:
+    """Finite-sample upper bound for a future exchangeable absolute error."""
+    x = np.sort(np.asarray(errors, dtype=np.float64).reshape(-1))
+    if not len(x):
+        raise ValueError("calibration needs at least one paired error")
+    if not 0.0 < coverage < 1.0:
+        raise ValueError("coverage must be between zero and one")
+    rank = int(math.ceil((len(x) + 1) * coverage))
+    return float(x[rank - 1]) if rank <= len(x) else float("inf")
+
+
+def br_shortfall_upper(exact_gaps, sampled_upper_gaps,
+                       coverage: float = DEFAULT_COVERAGE) -> float:
+    """One-sided conformal bound on sampled-BR optimization shortfall.
+
+    A trained candidate BR is a lower bound on the true best response. Its
+    evaluation upper confidence limit still may miss the optimum. This bound
+    calibrates that missing optimization mass against exact roots.
+    """
+    exact = np.asarray(exact_gaps, dtype=np.float64)
+    sampled = np.asarray(sampled_upper_gaps, dtype=np.float64)
+    if exact.shape != sampled.shape:
+        raise ValueError("exact and sampled gap arrays must have equal shape")
+    return conformal_upper(np.maximum(exact - sampled, 0.0), coverage)
+
+
+def calibrated_gap_interval(candidate_gains, candidate_ses, shortfall_bar,
+                            alpha: float = 0.05) -> tuple[float, float]:
+    """Simultaneous candidate interval plus calibrated shortfall.
+
+    ``alpha`` is the candidate-evaluation error budget only. The caller must
+    combine it with the shortfall calibration's miscoverage by a union bound;
+    for example, candidate alpha .025 plus 97.5% shortfall calibration gives
+    at least 95% joint coverage. ``audit_sampled_gap`` enforces this split.
+    """
+    gain = np.asarray(candidate_gains, dtype=np.float64).reshape(-1)
+    se = np.asarray(candidate_ses, dtype=np.float64).reshape(-1)
+    if not len(gain) or gain.shape != se.shape:
+        raise ValueError("candidate gains/SEs must be equal nonempty vectors")
+    if not 0.0 < alpha < 1.0:
+        raise ValueError("alpha must be between zero and one")
+    # Bonferroni two-sided normal interval for the fixed, independently
+    # evaluated BR candidates. Calibration covers their optimization miss.
+    z = NormalDist().inv_cdf(1.0 - alpha / (2.0 * len(gain)))
+    lower = max(0.0, float(np.max(gain - z * se)))
+    upper = max(0.0, float(np.max(gain + z * se))) + float(shortfall_bar)
+    return lower, upper
+
+
+def _load(path) -> dict[int, dict]:
+    rows = {}
+    for line in Path(path).read_text().splitlines():
+        if not line.strip():
+            continue
+        row = json.loads(line)
+        if row.get("verdict") not in ("converged", "gap_capped"):
+            continue
+        rows[int(row["seed"])] = row
+    return rows
+
+
+def _pairs(cpu, metal):
+    seeds = sorted(set(cpu) & set(metal))
+    if not seeds:
+        raise ValueError("paired ledgers have no usable seeds in common")
+    return [(s, cpu[s], metal[s]) for s in seeds]
+
+
+def _errors(pairs, field):
+    return np.asarray([abs(float(c[field]) - float(m[field]))
+                       for _, c, m in pairs], dtype=np.float64)
+
+
+def _margin_bins(pairs):
+    bins = ((0.0, 0.01), (0.01, 0.05), (0.05, 0.20),
+            (0.20, float("inf")))
+    out = []
+    for lo, hi in bins:
+        rows = [(c, m) for _, c, m in pairs
+                if "root_margin" in c and "root_argmax" in c
+                and "root_argmax" in m
+                and lo <= float(c["root_margin"]) < hi]
+        out.append({
+            "margin_lo": lo,
+            "margin_hi": None if math.isinf(hi) else hi,
+            "n": len(rows),
+            "argmax_changes": sum(int(c["root_argmax"])
+                                  != int(m["root_argmax"])
+                                  for c, m in rows),
+        })
+    return out
+
+
+def calibration_report(cal_pairs, hold_pairs,
+                       coverage: float = DEFAULT_COVERAGE,
+                       gap_target: float = DEFAULT_GAP_TARGET) -> dict:
+    value_bar = conformal_upper(_errors(cal_pairs, "cfr_reference_value"),
+                                coverage)
+    gap_bar = conformal_upper(_errors(cal_pairs, "final_gap"), coverage)
+    hv = _errors(hold_pairs, "cfr_reference_value")
+    hg = _errors(hold_pairs, "final_gap")
+
+    certain = wrong = uncertain = 0
+    for _, cpu, metal in hold_pairs:
+        truth = float(cpu["final_gap"]) <= gap_target
+        gm = float(metal["final_gap"])
+        if gm + gap_bar <= gap_target:
+            pred = True
+        elif gm - gap_bar > gap_target:
+            pred = False
+        else:
+            uncertain += 1
+            continue
+        certain += 1
+        wrong += pred != truth
+
+    return {
+        "contract": {
+            "method": "split-conformal absolute-error upper bound",
+            "coverage": coverage,
+            "gap_target": gap_target,
+            "calibration_n": len(cal_pairs),
+            "heldout_n": len(hold_pairs),
+        },
+        "value": {
+            "error_bar": value_bar,
+            "heldout_covered": int(np.sum(hv <= value_bar)),
+            "heldout_n": len(hv),
+            "heldout_max_error": float(np.max(hv)),
+        },
+        "gap": {
+            "error_bar": gap_bar,
+            "heldout_covered": int(np.sum(hg <= gap_bar)),
+            "heldout_n": len(hg),
+            "heldout_max_error": float(np.max(hg)),
+        },
+        "convergence": {
+            "certain_n": certain,
+            "uncertain_n": uncertain,
+            "wrong_when_certain": wrong,
+        },
+        "root_argmax_by_cpu_margin": _margin_bins(hold_pairs),
+    }
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--calibration-cpu", required=True)
+    ap.add_argument("--calibration-metal", required=True)
+    ap.add_argument("--heldout-cpu", required=True)
+    ap.add_argument("--heldout-metal", required=True)
+    ap.add_argument("--coverage", type=float, default=DEFAULT_COVERAGE)
+    ap.add_argument("--gap-target", type=float, default=DEFAULT_GAP_TARGET)
+    ap.add_argument("--out", required=True)
+    a = ap.parse_args(argv)
+
+    cal = _pairs(_load(a.calibration_cpu), _load(a.calibration_metal))
+    hold = _pairs(_load(a.heldout_cpu), _load(a.heldout_metal))
+    overlap = {s for s, _, _ in cal} & {s for s, _, _ in hold}
+    if overlap:
+        raise SystemExit(f"calibration/heldout seeds overlap: {sorted(overlap)}")
+    report = calibration_report(cal, hold, a.coverage, a.gap_target)
+    Path(a.out).write_text(json.dumps(report, indent=2) + "\n")
+    print(json.dumps(report, indent=2))
+    finite = math.isfinite(report["value"]["error_bar"]) and \
+        math.isfinite(report["gap"]["error_bar"])
+    covered = (report["value"]["heldout_covered"] / len(hold) >= a.coverage
+               and report["gap"]["heldout_covered"] / len(hold)
+               >= a.coverage)
+    return 0 if finite and covered else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/hoyt/metalkernel.py
+++ b/hoyt/metalkernel.py
@@ -1,0 +1,516 @@
+"""Device-resident float32 CFR+ iteration kernels for Hoyt.
+
+This module is intentionally narrower than :mod:`hoyt.cfr`: it owns the
+expensive alternating-update loop and exact-in-structure gap audit, while the
+standing CPU lane still owns the walk build and public profile export. Keeping
+that seam explicit lets us measure the first Metal vertical slice before
+attempting the GPU builder and batched H5/H6 scheduler.
+
+The arrays produced by one update remain MLX arrays throughout all iterations.
+Only ``average_numpy`` crosses back to the host, at a requested audit boundary.
+The arithmetic is float32 by design.  Metal is calibrated against the fp64
+lane; bit replication is not part of its contract.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+try:
+    import mlx.core as mx
+except ImportError as exc:  # pragma: no cover - exercised by fail-fast path
+    mx = None
+    _MLX_IMPORT_ERROR = exc
+else:
+    _MLX_IMPORT_ERROR = None
+
+__all__ = ["MetalCFR", "metal_available"]
+
+
+def metal_available() -> bool:
+    """Return whether MLX is present and its default device is a GPU."""
+    return mx is not None and "gpu" in str(mx.default_device()).lower()
+
+
+def _require_metal() -> None:
+    if mx is None:
+        raise RuntimeError(
+            "engine='metal' requires MLX (install burl/requirements-mlx.txt)"
+        ) from _MLX_IMPORT_ERROR
+    if "gpu" not in str(mx.default_device()).lower():
+        raise RuntimeError(
+            f"engine='metal' requires the MLX Metal GPU device; got "
+            f"{mx.default_device()}"
+        )
+
+
+def _launch(kernel, inputs, n, shapes, dtypes):
+    if n <= 0:
+        raise ValueError("Metal kernels require at least one output element")
+    return kernel(
+        inputs=inputs,
+        grid=(int(n), 1, 1),
+        threadgroup=(min(256, int(n)), 1, 1),
+        output_shapes=shapes,
+        output_dtypes=dtypes,
+    )
+
+
+_FWD_SOURCE = r"""
+    uint i = thread_position_in_grid.x;
+    if (i >= ps_shape[0]) return;
+    int p = ps[i];
+    int g = cgid[i];
+    float pr = g >= 0 ? sig[g] : 1.0f;
+    if ((int)eseat[i] == u[0]) {
+        rmu_c[i] = rmu_p[p];
+        ru_c[i] = ru_p[p] * pr;
+    } else {
+        rmu_c[i] = rmu_p[p] * pr;
+        ru_c[i] = ru_p[p];
+    }
+"""
+
+_BWD_MAP_SOURCE = r"""
+    uint i = thread_position_in_grid.x;
+    if (i >= ps_shape[0]) return;
+    int g = cgid[i];
+    float z = g >= 0 ? sig[g] * v_c[i] : v_c[i];
+    v_p[ps[i]] = z;
+"""
+
+_BWD_SEG_SOURCE = r"""
+    uint p = thread_position_in_grid.x;
+    if (p + 1 >= poff_shape[0]) return;
+    float acc = 0.0f;
+    for (int k = poff[p]; k < poff[p + 1]; ++k) {
+        int i = perm[k];
+        int g = cgid[i];
+        acc += g >= 0 ? sig[g] * v_c[i] : v_c[i];
+    }
+    v_p[p] = acc;
+"""
+
+_CF_SEG_SOURCE = r"""
+    uint gl = thread_position_in_grid.x;
+    if (gl >= gids_shape[0]) return;
+    float acc = 0.0f;
+    for (int k = goff[gl]; k < goff[gl + 1]; ++k) {
+        int i = perm[k];
+        acc += rmu_p[ps[i]] * v_c[i];
+    }
+    cf[gl] = acc;
+"""
+
+_RM_SOURCE = r"""
+    uint iu = thread_position_in_grid.x;
+    if (iu >= xi_shape[0]) return;
+    int a = iso[iu];
+    int b = iso[iu + 1];
+    float cfv = 0.0f;
+    for (int k = a; k < b; ++k) cfv += sig[k] * cf[k];
+    float txv = iteration[0] * xi[iu];
+    float total = 0.0f;
+    for (int k = a; k < b; ++k) {
+        avg_out[k] = avg[k] + txv * sig[k];
+        float r = reg[k] + sign[0] * (cf[k] - cfv);
+        r = r > 0.0f ? r : 0.0f;
+        reg_out[k] = r;
+        total += r;
+    }
+    if (total > 0.0f) {
+        for (int k = a; k < b; ++k) sig_out[k] = reg_out[k] / total;
+    } else {
+        for (int k = a; k < b; ++k) sig_out[k] = inv[k];
+    }
+"""
+
+_AVG_SOURCE = r"""
+    uint iu = thread_position_in_grid.x;
+    if (iu + 1 >= iso_shape[0]) return;
+    int a = iso[iu];
+    int b = iso[iu + 1];
+    float total = 0.0f;
+    for (int k = a; k < b; ++k) total += avg[k];
+    if (total > 0.0f) {
+        for (int k = a; k < b; ++k) out[k] = avg[k] / total;
+    } else {
+        for (int k = a; k < b; ++k) out[k] = inv[k];
+    }
+"""
+
+_BR_PICK_SOURCE = r"""
+    uint iu = thread_position_in_grid.x;
+    if (iu + 1 >= iso_shape[0]) return;
+    int a = iso[iu];
+    int b = iso[iu + 1];
+    int best = a;
+    float best_value = sign[0] * score[a];
+    for (int k = a + 1; k < b; ++k) {
+        float z = sign[0] * score[k];
+        if (z > best_value) {
+            best = k;
+            best_value = z;
+        }
+    }
+    for (int k = a; k < b; ++k) pick[k] = k == best ? 1.0f : 0.0f;
+"""
+
+_BR_BWD_MAP_SOURCE = r"""
+    uint i = thread_position_in_grid.x;
+    if (i >= ps_shape[0]) return;
+    int g = cgid[i];
+    float z;
+    if ((int)eseat[i] == u[0]) {
+        z = g >= 0 ? pick[g - base[0]] * v_c[i] : v_c[i];
+    } else {
+        z = g >= 0 ? sig[g] * v_c[i] : v_c[i];
+    }
+    v_p[ps[i]] = z;
+"""
+
+_BR_BWD_SEG_SOURCE = r"""
+    uint p = thread_position_in_grid.x;
+    if (p + 1 >= poff_shape[0]) return;
+    float acc = 0.0f;
+    for (int k = poff[p]; k < poff[p + 1]; ++k) {
+        int i = perm[k];
+        int g = cgid[i];
+        float z;
+        if ((int)eseat[i] == u[0]) {
+            z = g >= 0 ? pick[g - base[0]] * v_c[i] : v_c[i];
+        } else {
+            z = g >= 0 ? sig[g] * v_c[i] : v_c[i];
+        }
+        acc += z;
+    }
+    v_p[p] = acc;
+"""
+
+
+@dataclass(frozen=True)
+class _WaveArrays:
+    ps: object
+    cgid: object
+    eseat: object
+    poff: object | None
+    perm: object | None
+
+
+class MetalCFR:
+    """A float32 alternating CFR+ state whose iterate stays on Metal."""
+
+    def __init__(self, ws, fl, payleaf, sig0, live_seats):
+        _require_metal()
+        if not fl.par:
+            raise ValueError("MetalCFR requires _build_fused(..., par=True)")
+        self.ws = ws
+        self.fl = fl
+        self.live_seats = tuple(int(u) for u in live_seats)
+
+        self._fwd = mx.fast.metal_kernel(
+            name="hoyt_fwd", input_names=["ps", "cgid", "eseat", "u",
+            "sig", "rmu_p", "ru_p"], output_names=["rmu_c", "ru_c"],
+            source=_FWD_SOURCE)
+        self._bwd_map = mx.fast.metal_kernel(
+            name="hoyt_bwd_map", input_names=["ps", "cgid", "sig", "v_c"],
+            output_names=["v_p"], source=_BWD_MAP_SOURCE)
+        self._bwd_seg = mx.fast.metal_kernel(
+            name="hoyt_bwd_seg", input_names=["poff", "perm", "cgid",
+            "sig", "v_c"], output_names=["v_p"], source=_BWD_SEG_SOURCE)
+        self._cf_seg = mx.fast.metal_kernel(
+            name="hoyt_cf_seg", input_names=["goff", "gids", "perm", "ps",
+            "rmu_p", "v_c"], output_names=["cf"], source=_CF_SEG_SOURCE)
+        self._rm = mx.fast.metal_kernel(
+            name="hoyt_rm", input_names=["iso", "sig", "reg", "avg", "cf",
+            "xi", "inv", "sign", "iteration"],
+            output_names=["sig_out", "reg_out", "avg_out"], source=_RM_SOURCE)
+        self._avg = mx.fast.metal_kernel(
+            name="hoyt_avg", input_names=["iso", "avg", "inv"],
+            output_names=["out"], source=_AVG_SOURCE)
+        self._br_pick = mx.fast.metal_kernel(
+            name="hoyt_br_pick", input_names=["iso", "score", "sign"],
+            output_names=["pick"], source=_BR_PICK_SOURCE)
+        self._br_bwd_map = mx.fast.metal_kernel(
+            name="hoyt_br_bwd_map", input_names=["ps", "cgid", "eseat",
+            "u", "sig", "v_c", "pick", "base"],
+            output_names=["v_p"], source=_BR_BWD_MAP_SOURCE)
+        self._br_bwd_seg = mx.fast.metal_kernel(
+            name="hoyt_br_bwd_seg", input_names=["poff", "perm", "ps",
+            "cgid", "eseat", "u", "sig", "v_c", "pick", "base"],
+            output_names=["v_p"], source=_BR_BWD_SEG_SOURCE)
+
+        self.waves = []
+        for j in range(ws.L):
+            seg = fl.vseg[j]
+            poff = perm = None
+            if seg is not None:
+                poff = mx.array(seg[0].astype(np.int32, copy=False))
+                perm = mx.array(seg[1])
+            self.waves.append(_WaveArrays(
+                ps=mx.array(fl.ps32[j]), cgid=mx.array(fl.cgid32[j]),
+                eseat=mx.array(fl.eseat8[j]), poff=poff, perm=perm))
+
+        self.ciju = {}
+        for key, (cids, reps) in fl.c_iju.items():
+            self.ciju[key] = (np.asarray(cids, dtype=np.int64),
+                              mx.array(np.asarray(reps, dtype=np.int32)))
+        self.cfju = {}
+        for key, (goff, gids, perm) in fl.cf_ju.items():
+            labels = fl.c_isl_loc[gids]
+            local = labels - labels[0]
+            niso = int(local[-1]) + 1
+            iso = np.searchsorted(local, np.arange(niso + 1)) \
+                .astype(np.int32)
+            self.cfju[key] = (
+                mx.array(goff.astype(np.int32, copy=False)),
+                np.asarray(gids, dtype=np.int64),
+                mx.array(np.asarray(gids, dtype=np.int32)),
+                mx.array(perm),
+                mx.array(iso),
+                mx.array([int(gids[0])], dtype=mx.int32),
+            )
+
+        self.iso = {}
+        self.inv = {}
+        self.sig = {}
+        self.reg = {}
+        self.avg = {}
+        for u in range(4):
+            a, b = int(fl.c_soff[u]), int(fl.c_soff[u + 1])
+            self.iso[u] = mx.array(fl.iso[u].astype(np.int32, copy=False))
+            self.inv[u] = mx.array(
+                np.asarray(fl.inv_nleg[a:b], dtype=np.float32))
+            self.sig[u] = mx.array(np.asarray(sig0[fl.c_flat[a:b]],
+                                               dtype=np.float32))
+            self.reg[u] = mx.zeros((b - a,), dtype=mx.float32)
+            self.avg[u] = mx.zeros((b - a,), dtype=mx.float32)
+
+        self.w0 = mx.array(np.asarray(fl.w0, dtype=np.float32))
+        self.payleaf = mx.array(np.asarray(payleaf, dtype=np.float32))
+        self._ones = mx.ones((ws.S[0],), dtype=mx.float32)
+        self._u = {u: mx.array([u], dtype=mx.int32) for u in range(4)}
+        self._sign = {
+            -1: mx.array([-1.0], dtype=mx.float32),
+            1: mx.array([1.0], dtype=mx.float32),
+        }
+        self._assert_layout()
+        mx.reset_peak_memory()
+        mx.eval(self.w0, self.payleaf, list(self.sig.values()),
+                list(self.reg.values()), list(self.avg.values()))
+
+    def _assert_layout(self):
+        for u in range(4):
+            cids = []
+            gids = []
+            for j in range(self.ws.L):
+                got = self.ciju.get((j, u))
+                if got is not None:
+                    cids.extend(got[0].tolist())
+                got = self.cfju.get((j, u))
+                if got is not None:
+                    gids.extend(got[1].tolist())
+            want_i = list(range(int(self.fl.c_isoff[u]),
+                                int(self.fl.c_isoff[u + 1])))
+            want_g = list(range(int(self.fl.c_soff[u]),
+                                int(self.fl.c_soff[u + 1])))
+            if cids != want_i or gids != want_g:
+                raise ValueError(
+                    "Metal layout requires wave-major contiguous seat slices")
+
+    def _global_sig(self):
+        return mx.concatenate([self.sig[u] for u in range(4)])
+
+    def update(self, u: int, sign: int, iteration: int) -> None:
+        """Queue one seat update; all inputs and outputs remain on device."""
+        ni = int(self.fl.c_isoff[u + 1] - self.fl.c_isoff[u])
+        if ni == 0:
+            return
+        sig = self._global_sig()
+        rmu = self.w0
+        ru = self._ones
+        rmu_store = []
+        xi_parts = []
+        for j, wave in enumerate(self.waves):
+            got = self.ciju.get((j, u))
+            if got is not None:
+                xi_parts.append(ru[got[1]])
+            rmu_store.append(rmu)
+            n = int(self.ws.S[j + 1])
+            rmu, ru = _launch(
+                self._fwd,
+                [wave.ps, wave.cgid, wave.eseat, self._u[u], sig, rmu, ru],
+                n, [(n,), (n,)], [mx.float32, mx.float32])
+
+        v = self.payleaf
+        cf_parts = []
+        for j in range(self.ws.L - 1, -1, -1):
+            wave = self.waves[j]
+            got = self.cfju.get((j, u))
+            if got is not None:
+                goff, gids, gids_dev, perm, _iso, _base = got
+                ng = len(gids)
+                cf_parts.append((j, _launch(
+                    self._cf_seg,
+                    [goff, gids_dev, perm, wave.ps, rmu_store[j], v],
+                    ng, [(ng,)], [mx.float32])[0]))
+            np_ = int(self.ws.S[j])
+            if wave.poff is None:
+                v, = _launch(self._bwd_map,
+                             [wave.ps, wave.cgid, sig, v], np_, [(np_,)],
+                             [mx.float32])
+            else:
+                v, = _launch(self._bwd_seg,
+                             [wave.poff, wave.perm, wave.cgid, sig, v], np_,
+                             [(np_,)], [mx.float32])
+
+        # The fused layout is wave-major.  Backward traversal discovered the
+        # pieces in reverse, so restore wave order before concatenation.
+        cf = mx.concatenate([part for _, part in sorted(cf_parts)])
+        xi = mx.concatenate(xi_parts)
+        ns = int(self.fl.c_soff[u + 1] - self.fl.c_soff[u])
+        sig, reg, avg = _launch(
+            self._rm,
+            [self.iso[u], self.sig[u], self.reg[u], self.avg[u], cf, xi,
+             self.inv[u], self._sign[int(sign)],
+             mx.array([float(iteration)], dtype=mx.float32)],
+            ni, [(ns,), (ns,), (ns,)],
+            [mx.float32, mx.float32, mx.float32])
+        self.sig[u], self.reg[u], self.avg[u] = sig, reg, avg
+        # Materialize each alternating update without transferring it.  This
+        # bounds MLX's lazy graph and lets temporary wave buffers be reclaimed.
+        # A long async chain can release custom-kernel intermediates before
+        # Metal has consumed them (observed as a GPU address fault on w12), so
+        # the explicit device synchronization is a correctness boundary for
+        # this first lane.
+        mx.eval(sig, reg, avg)
+
+    def round(self, signs: dict[int, int], iteration: int) -> None:
+        for u in self.live_seats:
+            self.update(u, signs[u], iteration)
+
+    def average_numpy(self) -> np.ndarray:
+        """Return a full-slot average profile at an explicit audit boundary."""
+        compressed = np.asarray(self.average_device(), dtype=np.float32) \
+            .astype(np.float64)
+        # Public profiles require each distribution to sum to one at fp64
+        # tolerance. Float32 division can leave a few ulps of residue; repair
+        # that representation boundary without changing the Metal iterate.
+        for u in self.live_seats:
+            base = int(self.fl.c_soff[u])
+            iso = np.asarray(self.fl.iso[u], dtype=np.int64)
+            a, b = base, int(self.fl.c_soff[u + 1])
+            if b > a:
+                totals = np.add.reduceat(compressed[a:b], iso[:-1])
+                compressed[a:b] /= np.repeat(totals, np.diff(iso))
+        out = self.fl.sig0_full.copy()
+        out[self.fl.c_flat] = compressed
+        return out
+
+    def average_device(self):
+        """Return the compressed average profile without leaving Metal."""
+        parts = []
+        for u in range(4):
+            if u not in self.live_seats:
+                parts.append(self.sig[u])
+                continue
+            ni = int(self.fl.c_isoff[u + 1] - self.fl.c_isoff[u])
+            ns = int(self.fl.c_soff[u + 1] - self.fl.c_soff[u])
+            if ni == 0:
+                parts.append(self.sig[u])
+                continue
+            out, = _launch(self._avg, [self.iso[u], self.avg[u], self.inv[u]],
+                           ni, [(ns,)], [mx.float32])
+            parts.append(out)
+        return mx.concatenate(parts)
+
+    def _backward_value(self, sig):
+        v = self.payleaf
+        for j in range(self.ws.L - 1, -1, -1):
+            wave = self.waves[j]
+            np_ = int(self.ws.S[j])
+            if wave.poff is None:
+                v, = _launch(self._bwd_map, [wave.ps, wave.cgid, sig, v],
+                             np_, [(np_,)], [mx.float32])
+            else:
+                v, = _launch(self._bwd_seg,
+                             [wave.poff, wave.perm, wave.cgid, sig, v],
+                             np_, [(np_,)], [mx.float32])
+        return mx.sum(self.w0 * v) / np.float32(self.ws.total_w)
+
+    def _best_response(self, sig, u: int, sign: int):
+        rmu = self.w0
+        ru = self._ones
+        rmu_store = []
+        for wave in self.waves:
+            rmu_store.append(rmu)
+            n = int(wave.ps.shape[0])
+            rmu, ru = _launch(
+                self._fwd,
+                [wave.ps, wave.cgid, wave.eseat, self._u[u], sig, rmu, ru],
+                n, [(n,), (n,)], [mx.float32, mx.float32])
+
+        v = self.payleaf
+        empty_pick = mx.zeros((1,), dtype=mx.float32)
+        zero_base = mx.array([0], dtype=mx.int32)
+        for j in range(self.ws.L - 1, -1, -1):
+            wave = self.waves[j]
+            got = self.cfju.get((j, u))
+            if got is None:
+                pick, base = empty_pick, zero_base
+            else:
+                goff, gids, gids_dev, perm, iso, base = got
+                ng = len(gids)
+                score, = _launch(
+                    self._cf_seg,
+                    [goff, gids_dev, perm, wave.ps, rmu_store[j], v],
+                    ng, [(ng,)], [mx.float32])
+                ni = int(iso.shape[0]) - 1
+                pick, = _launch(self._br_pick,
+                                [iso, score, self._sign[int(sign)]], ni,
+                                [(ng,)], [mx.float32])
+            np_ = int(self.ws.S[j])
+            if wave.poff is None:
+                v, = _launch(
+                    self._br_bwd_map,
+                    [wave.ps, wave.cgid, wave.eseat, self._u[u], sig, v,
+                     pick, base], np_, [(np_,)], [mx.float32])
+            else:
+                v, = _launch(
+                    self._br_bwd_seg,
+                    [wave.poff, wave.perm, wave.ps, wave.cgid, wave.eseat,
+                     self._u[u], sig, v, pick, base],
+                    np_, [(np_,)], [mx.float32])
+        return mx.sum(self.w0 * v) / np.float32(self.ws.total_w)
+
+    def measure(self, signs: dict[int, int]):
+        """GPU value and exact-in-structure single-seat BR gap."""
+        sig = self.average_device()
+        vbar = self._backward_value(sig)
+        brs = {u: self._best_response(sig, u, signs[u])
+               for u in self.live_seats}
+        mx.eval(vbar, brs)
+        value = float(vbar.item())
+        gap = max((signs[u] * (float(brs[u].item()) - value)
+                   for u in self.live_seats), default=0.0)
+        return value, gap
+
+    def debug_numpy(self):
+        mx.synchronize()
+        return {
+            "sig_c": np.asarray(self._global_sig(), dtype=np.float32),
+            "reg_c": np.asarray(mx.concatenate([self.reg[u]
+                                                 for u in range(4)]),
+                                dtype=np.float32),
+            "avg_c": np.asarray(mx.concatenate([self.avg[u]
+                                                 for u in range(4)]),
+                                dtype=np.float32),
+        }
+
+    @property
+    def peak_memory(self) -> int:
+        return int(mx.get_peak_memory())
+
+    def synchronize(self) -> None:
+        mx.synchronize()

--- a/hoyt/play.py
+++ b/hoyt/play.py
@@ -1,0 +1,620 @@
+"""Play a late-hand continuation against bounded full-Metal Hoyt.
+
+This is deliberately a *player experiment*, not a new reference claim.  Each
+seat independently re-solves from its own information set: its remaining hand,
+the public auction, and the public play history.  The real hidden deal is used
+only by the zeb referee to apply actions; it never enters ``EndgameRoot`` or the
+solver seed.
+
+The default table starts at H5 after Jud has supplied a deterministic opening
+prefix.  From there a human controls the current leader and the other three
+seats use sparse external-sampling CFR on Metal.  A JSON session in ``scratch``
+makes the table resumable and lets a conversation drive one human move at a
+time without exposing the other hands.
+
+Honesty line: action intervals below cover independent finite-sample
+evaluation of the fixed candidate only.  They do not cover CFR optimization
+shortfall, do not certify equilibrium, and do not make the physical-uniform
+belief behavior-conditioned on earlier actions.
+"""
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+import hashlib
+import json
+from pathlib import Path
+import time
+from typing import Callable, Sequence
+
+from arena.play import PlayPolicy, RandomPlay
+from forge.oracle.declarations import DECL_ID_TO_NAME
+from forge.oracle.tables import DOMINOES, resolve_trick
+from forge.zeb.game import (
+    apply_action,
+    current_player,
+    is_terminal,
+    legal_actions,
+    new_game,
+)
+from forge.zeb.types import BidState, GamePhase, ZebGameState
+from hoyt.br import payoff_make, payoff_points
+from hoyt.sampled_br import SampledCFR
+from walt.contracts import EndgameRoot
+
+__all__ = [
+    "HoytDecision",
+    "HoytPlay",
+    "SolveBudget",
+    "TableSession",
+    "advance_to_horizon",
+    "format_domino",
+    "load_session",
+    "render_position",
+    "root_from_state",
+    "save_session",
+]
+
+_SEAT_NAMES = ("North", "East", "South", "West")
+_SESSION_VERSION = 1
+
+
+@dataclass(frozen=True)
+class SolveBudget:
+    """One registered amount of work for an acting-seat re-solve."""
+
+    epochs: int
+    train_batch: int
+    eval_batches: int
+    eval_batch: int
+    capacity: int = 1 << 20
+
+
+_DEFAULT_BUDGETS = {
+    # H5/H6 are the measured full-Metal shapes.  Smaller horizons retain the
+    # H5 budget but become rapidly cheaper as the remaining tree contracts.
+    6: SolveBudget(epochs=50, train_batch=32,
+                   eval_batches=8, eval_batch=128),
+    5: SolveBudget(epochs=100, train_batch=64,
+                   eval_batches=8, eval_batch=256),
+    4: SolveBudget(epochs=100, train_batch=64,
+                   eval_batches=8, eval_batch=256),
+    3: SolveBudget(epochs=120, train_batch=64,
+                   eval_batches=8, eval_batch=256),
+    2: SolveBudget(epochs=120, train_batch=64,
+                   eval_batches=8, eval_batch=256),
+    1: SolveBudget(epochs=0, train_batch=1,
+                   eval_batches=1, eval_batch=2),
+}
+
+
+@dataclass(frozen=True)
+class HoytDecision:
+    """Public receipt for one acting-seat decision.
+
+    ``margin`` and ``margin_error`` are in the selected utility's units:
+    declaring points for ``points`` and probability for ``make``.  The error
+    is the sum of the simultaneous empirical-Bernstein radii on the top two
+    candidate actions.  ``separated`` therefore means the fixed-candidate
+    evaluation bands do not overlap; it is not an optimization certificate.
+    """
+
+    seat: int
+    horizon: int
+    action: int                 # zeb slot index
+    domino: int                 # public domino id
+    utility: str
+    value: float | None
+    value_error: float | None
+    margin: float | None
+    margin_error: float | None
+    separated: bool | None
+    n_worlds: int | None
+    samples: int
+    rows: int
+    peak_frontier: int
+    wall_seconds: float
+    forced: bool = False
+
+
+def _remaining(state: ZebGameState, seat: int) -> tuple[int, ...]:
+    return tuple(d for d in state.hands[seat] if d not in state.played)
+
+
+def root_from_state(state: ZebGameState) -> EndgameRoot:
+    """Project a referee state to exactly what the acting seat may know."""
+    if state.phase != GamePhase.PLAYING:
+        raise ValueError("Hoyt can only solve a playing state")
+    me = current_player(state)
+    return EndgameRoot(
+        decl_id=int(state.decl_id),
+        bidder=int(state.bidder),
+        bid_value=int(state.bid_state.high_bid),
+        bids=tuple(int(x) for x in state.bid_state.bids),
+        dealer=int(state.dealer),
+        me=me,
+        my_hand=tuple(sorted(_remaining(state, me))),
+        play_history=tuple((int(s), int(d)) for s, d in state.play_history),
+        trick_leader=int(state.trick_leader),
+        current_trick=tuple(int(d) for d in state.current_trick),
+        team_points=tuple(int(x) for x in state.team_points),
+    )
+
+
+def _decision_seed(root: EndgameRoot, base_seed: int) -> int:
+    """Stable seed derived only from the acting seat's information state."""
+    payload = repr((int(base_seed), root)).encode("utf-8")
+    return int.from_bytes(hashlib.blake2b(payload, digest_size=8).digest(),
+                          "little") & 0x7FFF_FFFF
+
+
+class HoytPlay(PlayPolicy):
+    """Arena-shaped late-hand player backed by a fresh sampled-CFR re-solve."""
+
+    def __init__(
+        self,
+        *,
+        utility: str = "make",
+        seed: int = 0,
+        budgets: dict[int, SolveBudget] | None = None,
+    ):
+        if utility not in ("make", "points"):
+            raise ValueError("utility must be 'make' or 'points'")
+        self.utility = utility
+        self.seed = int(seed)
+        self.budgets = dict(_DEFAULT_BUDGETS if budgets is None else budgets)
+        self.last_decisions: list[HoytDecision] = []
+
+    def _budget(self, horizon: int) -> SolveBudget:
+        if horizon not in self.budgets:
+            raise ValueError(
+                f"no playable full-Metal budget for H{horizon}; "
+                "start the table at H5 or H6")
+        return self.budgets[horizon]
+
+    def _choose_one(self, state: ZebGameState) -> HoytDecision:
+        legal = tuple(int(a) for a in legal_actions(state))
+        seat = current_player(state)
+        horizon = len(_remaining(state, seat))
+        if len(legal) == 1:
+            action = legal[0]
+            return HoytDecision(
+                seat=seat, horizon=horizon, action=action,
+                domino=int(state.hands[seat][action]), utility=self.utility,
+                value=None, value_error=None, margin=None, margin_error=None,
+                separated=None, n_worlds=None, samples=0, rows=0,
+                peak_frontier=0, wall_seconds=0.0, forced=True)
+
+        budget = self._budget(horizon)
+        root = root_from_state(state)
+        payoff = (payoff_make(root.bid_value) if self.utility == "make"
+                  else payoff_points())
+        solve_seed = _decision_seed(root, self.seed)
+        t0 = time.perf_counter()
+        solver = SampledCFR(root, payoff, capacity=budget.capacity)
+        solver.train(budget.epochs, budget.train_batch, seed=solve_seed)
+        result = solver.evaluate(
+            budget.eval_batches, budget.eval_batch,
+            seed=solve_seed + 10_000_000,
+        )
+        wall = time.perf_counter() - t0
+        if result.best_move is None:
+            raise RuntimeError("sampled CFR returned no root move")
+
+        domino = int(result.best_move)
+        try:
+            action = tuple(state.hands[seat]).index(domino)
+        except ValueError as exc:  # pragma: no cover - kernel invariant
+            raise AssertionError("Hoyt returned a tile outside the acting hand") \
+                from exc
+        if action not in legal:  # pragma: no cover - kernel invariant
+            raise AssertionError("Hoyt returned a follow-suit-illegal tile")
+
+        sign = 1.0 if seat % 2 == state.bidder % 2 else -1.0
+        ranked = sorted(
+            ((sign * float(v), int(move))
+             for move, v in result.root_values.items()),
+            key=lambda pair: (-pair[0], pair[1]),
+        )
+        best_oriented, best_move = ranked[0]
+        if best_move != domino:
+            raise AssertionError("root value ranking disagrees with best_move")
+        value = float(result.root_values[domino])
+        value_error = float(result.root_value_error[domino])
+        if len(ranked) > 1:
+            second_oriented, second_move = ranked[1]
+            margin = best_oriented - second_oriented
+            margin_error = value_error \
+                + float(result.root_value_error[second_move])
+            separated = bool(margin > margin_error)
+        else:  # legal length >1 above, retained as a defensive invariant
+            margin = None
+            margin_error = None
+            separated = None
+
+        return HoytDecision(
+            seat=seat, horizon=horizon, action=action, domino=domino,
+            utility=self.utility, value=value, value_error=value_error,
+            margin=margin, margin_error=margin_error, separated=separated,
+            n_worlds=int(solver.sampler.n_worlds), samples=int(result.samples),
+            rows=int(result.occupied_buckets),
+            peak_frontier=int(result.peak_frontier), wall_seconds=wall)
+
+    def choose(
+        self,
+        states: Sequence[ZebGameState],
+        bid_values: Sequence[int],
+        marks: Sequence[tuple[int, int]] | None = None,
+        marks_to_win: int = 7,
+    ) -> list[int]:
+        del marks, marks_to_win
+        if len(states) != len(bid_values):
+            raise ValueError("states and bid_values must have equal length")
+        decisions = [self._choose_one(state) for state in states]
+        self.last_decisions = decisions
+        return [d.action for d in decisions]
+
+    def __repr__(self) -> str:
+        return f"HoytPlay(utility={self.utility!r})"
+
+
+@dataclass
+class TableSession:
+    state: ZebGameState
+    human_seat: int
+    seed: int
+    start_horizon: int
+    prefix: str
+    utility: str = "make"
+    bot_seed: int = 42
+
+
+def advance_to_horizon(
+    seed: int,
+    horizon: int,
+    prefix_policy: PlayPolicy,
+) -> ZebGameState:
+    """Play a public prefix until the next mover holds ``horizon`` tiles."""
+    if horizon not in (5, 6):
+        raise ValueError("the playable entry horizon must be H5 or H6")
+    state = new_game(int(seed))
+    while not is_terminal(state):
+        mover = current_player(state)
+        if len(_remaining(state, mover)) <= horizon:
+            return state
+        action = prefix_policy.choose(
+            [state], [int(state.bid_state.high_bid)])[0]
+        state = apply_action(state, int(action))
+    raise RuntimeError("hand ended before the requested entry horizon")
+
+
+def _state_to_dict(state: ZebGameState) -> dict:
+    return {
+        "hands": [list(map(int, h)) for h in state.hands],
+        "dealer": int(state.dealer),
+        "phase": int(state.phase),
+        "bid_state": {
+            "bids": list(map(int, state.bid_state.bids)),
+            "high_bidder": int(state.bid_state.high_bidder),
+            "high_bid": int(state.bid_state.high_bid),
+        },
+        "decl_id": int(state.decl_id),
+        "bidder": int(state.bidder),
+        "played": sorted(map(int, state.played)),
+        "play_history": [list(map(int, x)) for x in state.play_history],
+        "current_trick": list(map(int, state.current_trick)),
+        "trick_leader": int(state.trick_leader),
+        "team_points": list(map(int, state.team_points)),
+    }
+
+
+def _state_from_dict(data: dict) -> ZebGameState:
+    bid = data["bid_state"]
+    return ZebGameState(
+        hands=tuple(tuple(map(int, h)) for h in data["hands"]),
+        dealer=int(data["dealer"]),
+        phase=GamePhase(int(data["phase"])),
+        bid_state=BidState(
+            bids=tuple(map(int, bid["bids"])),
+            high_bidder=int(bid["high_bidder"]),
+            high_bid=int(bid["high_bid"]),
+        ),
+        decl_id=int(data["decl_id"]),
+        bidder=int(data["bidder"]),
+        played=frozenset(map(int, data["played"])),
+        play_history=tuple(tuple(map(int, x))
+                           for x in data["play_history"]),
+        current_trick=tuple(map(int, data["current_trick"])),
+        trick_leader=int(data["trick_leader"]),
+        team_points=tuple(map(int, data["team_points"])),
+    )
+
+
+def save_session(session: TableSession, path: str | Path) -> None:
+    target = Path(path)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "format_version": _SESSION_VERSION,
+        "human_seat": int(session.human_seat),
+        "seed": int(session.seed),
+        "start_horizon": int(session.start_horizon),
+        "prefix": session.prefix,
+        "utility": session.utility,
+        "bot_seed": int(session.bot_seed),
+        "state": _state_to_dict(session.state),
+    }
+    tmp = target.with_suffix(target.suffix + ".tmp")
+    tmp.write_text(json.dumps(payload, indent=2) + "\n")
+    tmp.replace(target)
+
+
+def load_session(path: str | Path) -> TableSession:
+    payload = json.loads(Path(path).read_text())
+    if int(payload.get("format_version", -1)) != _SESSION_VERSION:
+        raise ValueError("unsupported full-Metal table session version")
+    return TableSession(
+        state=_state_from_dict(payload["state"]),
+        human_seat=int(payload["human_seat"]),
+        seed=int(payload["seed"]),
+        start_horizon=int(payload["start_horizon"]),
+        prefix=str(payload["prefix"]),
+        utility=str(payload.get("utility", "make")),
+        bot_seed=int(payload.get("bot_seed", 42)),
+    )
+
+
+def format_domino(domino: int) -> str:
+    high, low = DOMINOES[int(domino)]
+    return f"{high}-{low}"
+
+
+def _parse_domino(text: str) -> tuple[int, int]:
+    clean = text.strip().lower().replace("domino", "").strip()
+    if clean.isdigit() and len(clean) == 1:
+        return -1, int(clean)  # displayed choice number, resolved by caller
+    clean = clean.replace("/", "-").replace(" ", "-")
+    if "-" not in clean and len(clean) == 2 and clean.isdigit():
+        clean = f"{clean[0]}-{clean[1]}"
+    parts = [p for p in clean.split("-") if p]
+    if len(parts) != 2 or not all(p.isdigit() for p in parts):
+        raise ValueError("enter a choice number or a tile such as 6-5")
+    a, b = map(int, parts)
+    if not (0 <= a <= 6 and 0 <= b <= 6):
+        raise ValueError("domino pips must be between 0 and 6")
+    high, low = max(a, b), min(a, b)
+    return high, low
+
+
+def _action_from_text(state: ZebGameState, text: str) -> int:
+    legal = tuple(map(int, legal_actions(state)))
+    high, low = _parse_domino(text)
+    if high == -1:
+        choice = low
+        if not 1 <= choice <= len(legal):
+            raise ValueError(f"choice must be between 1 and {len(legal)}")
+        return legal[choice - 1]
+    wanted = (high, low)
+    seat = current_player(state)
+    for action in legal:
+        if DOMINOES[state.hands[seat][action]] == wanted:
+            return action
+    raise ValueError(f"{high}-{low} is not a legal tile here")
+
+
+def _trick_lines(state: ZebGameState) -> list[str]:
+    lines = []
+    history = list(state.play_history)
+    for off in range(0, len(history), 4):
+        plays = history[off:off + 4]
+        labels = "  ".join(
+            f"{_SEAT_NAMES[seat]} {format_domino(tile)}"
+            for seat, tile in plays)
+        if len(plays) == 4:
+            leader = int(plays[0][0])
+            tiles = tuple(int(tile) for _, tile in plays)
+            outcome = resolve_trick(tiles[0], tiles, state.decl_id)
+            winner = (leader + int(outcome.winner_offset)) % 4
+            lines.append(
+                f"Trick {off // 4 + 1}: {labels}  -> "
+                f"{_SEAT_NAMES[winner]}, {int(outcome.points)} point(s)")
+        else:
+            lines.append(f"Current trick: {labels}")
+    return lines
+
+
+def render_position(session: TableSession) -> str:
+    """Render only public state plus the human seat's remaining hand."""
+    state = session.state
+    human = session.human_seat
+    bidder = int(state.bidder)
+    declaring = bidder % 2
+    role = "declaring team" if human % 2 == declaring else "defending team"
+    partner = (human + 2) % 4
+    lines = [
+        f"Full-Metal Hoyt table — seed {session.seed}",
+        f"You are {_SEAT_NAMES[human]} ({role}); "
+        f"your partner is {_SEAT_NAMES[partner]}.",
+        f"{_SEAT_NAMES[bidder]} bid {state.bid_state.high_bid}; "
+        f"trump is {DECL_ID_TO_NAME[state.decl_id]}.",
+        f"Banked points: team North/South {state.team_points[0]}, "
+        f"team East/West {state.team_points[1]}.",
+    ]
+    trick_lines = _trick_lines(state)
+    if trick_lines:
+        lines.extend(["", *trick_lines])
+    if is_terminal(state):
+        made = state.team_points[declaring] >= state.bid_state.high_bid
+        lines.extend([
+            "",
+            f"Final: North/South {state.team_points[0]}, "
+            f"East/West {state.team_points[1]}. "
+            f"The bid was {'made' if made else 'set'}.",
+        ])
+        return "\n".join(lines)
+    if current_player(state) != human:
+        lines.extend(["", f"Waiting for {_SEAT_NAMES[current_player(state)]}."])
+        return "\n".join(lines)
+
+    remaining = _remaining(state, human)
+    legal = tuple(map(int, legal_actions(state)))
+    lines.extend(["", "Your remaining hand: "
+                  + "  ".join(format_domino(d) for d in remaining),
+                  "Your legal plays:"])
+    for i, action in enumerate(legal, 1):
+        lines.append(f"  {i}. {format_domino(state.hands[human][action])}")
+    return "\n".join(lines)
+
+
+def _format_decision(decision: HoytDecision) -> str:
+    seat = _SEAT_NAMES[decision.seat]
+    tile = format_domino(decision.domino)
+    if decision.forced:
+        return f"{seat} plays {tile} (forced)."
+    confidence = "separated" if decision.separated else "close"
+    if decision.utility == "make":
+        edge = 100.0 * float(decision.margin or 0.0)
+        error = 100.0 * float(decision.margin_error or 0.0)
+        measure = f"estimated edge {edge:.1f} pp, band ±{error:.1f} pp"
+    else:
+        edge = float(decision.margin or 0.0)
+        error = float(decision.margin_error or 0.0)
+        measure = f"estimated edge {edge:.2f} Q, band ±{error:.2f} Q"
+    return (f"{seat} plays {tile} — {confidence} ({measure}; "
+            f"{decision.wall_seconds:.1f}s, "
+            f"{decision.n_worlds:,} physical worlds).")
+
+
+def _prefix_policy(name: str, seed: int) -> PlayPolicy:
+    if name == "random":
+        return RandomPlay(seed ^ 0x5052_4546)
+    if name != "jud":
+        raise ValueError("prefix must be 'jud' or 'random'")
+    import torch
+    from arena.jud_play import JudPlay
+    from champion.jud_net import load_jud_net
+
+    torch.set_num_threads(1)
+    return JudPlay(load_jud_net("champion/jud_net.pt", device="cpu"))
+
+
+def _new_session(args) -> TableSession:
+    policy = _prefix_policy(args.prefix, args.seed)
+    state = advance_to_horizon(args.seed, args.horizon, policy)
+    return TableSession(
+        state=state,
+        human_seat=current_player(state),
+        seed=args.seed,
+        start_horizon=args.horizon,
+        prefix=args.prefix,
+        utility=args.utility,
+        bot_seed=args.bot_seed,
+    )
+
+
+def _advance_bots(
+    session: TableSession,
+    bot: HoytPlay,
+    save: Callable[[], None],
+) -> list[HoytDecision]:
+    decisions = []
+    while not is_terminal(session.state) \
+            and current_player(session.state) != session.human_seat:
+        state = session.state
+        action = bot.choose([state], [state.bid_state.high_bid])[0]
+        decision = bot.last_decisions[0]
+        session.state = apply_action(state, action)
+        save()
+        decisions.append(decision)
+    return decisions
+
+
+def _hint(session: TableSession, bot: HoytPlay) -> HoytDecision:
+    if is_terminal(session.state):
+        raise ValueError("the hand is over")
+    if current_player(session.state) != session.human_seat:
+        raise ValueError("it is not the human seat's turn")
+    bot.choose([session.state], [session.state.bid_state.high_bid])
+    return bot.last_decisions[0]
+
+
+def _interactive(session: TableSession, path: Path, bot: HoytPlay) -> int:
+    while True:
+        print("\n" + render_position(session), flush=True)
+        if is_terminal(session.state):
+            return 0
+        try:
+            text = input("\nPlay a number/tile, ask for 'hint', or 'quit': ").strip()
+        except EOFError:
+            print()
+            return 0
+        if text.lower() in ("q", "quit", "exit"):
+            return 0
+        if text.lower() in ("h", "hint", "?"):
+            print("Hoyt is solving your seat...", flush=True)
+            print(_format_decision(_hint(session, bot)), flush=True)
+            continue
+        try:
+            action = _action_from_text(session.state, text)
+        except ValueError as exc:
+            print(f"No play made: {exc}", flush=True)
+            continue
+        session.state = apply_action(session.state, action)
+        save_session(session, path)
+        for decision in _advance_bots(
+                session, bot, lambda: save_session(session, path)):
+            print(_format_decision(decision), flush=True)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Play an H5/H6 continuation against full-Metal Hoyt")
+    parser.add_argument("--state", type=Path,
+                        default=Path("scratch/full-metal-table/session.json"))
+    parser.add_argument("--new", action="store_true",
+                        help="replace the named scratch session")
+    parser.add_argument("--seed", type=int, default=910000)
+    parser.add_argument("--horizon", type=int, choices=(5, 6), default=5)
+    parser.add_argument("--prefix", choices=("jud", "random"), default="jud")
+    parser.add_argument("--utility", choices=("make", "points"), default="make")
+    parser.add_argument("--bot-seed", type=int, default=42)
+    parser.add_argument("--move", type=str,
+                        help="make one human play, then run to the next human turn")
+    parser.add_argument("--hint", action="store_true",
+                        help="solve the current human decision without playing it")
+    parser.add_argument("--interactive", action="store_true",
+                        help="stay at the table until quit or hand end")
+    args = parser.parse_args()
+
+    if args.new:
+        session = _new_session(args)
+        save_session(session, args.state)
+    else:
+        session = load_session(args.state)
+    bot = HoytPlay(utility=session.utility, seed=session.bot_seed)
+
+    if args.hint:
+        print(render_position(session), flush=True)
+        print("\nHoyt is solving your seat...", flush=True)
+        print(_format_decision(_hint(session, bot)), flush=True)
+        return 0
+    if args.move is not None:
+        if is_terminal(session.state):
+            raise ValueError("the hand is already over")
+        if current_player(session.state) != session.human_seat:
+            raise ValueError("the saved table is waiting for a bot seat")
+        action = _action_from_text(session.state, args.move)
+        session.state = apply_action(session.state, action)
+        save_session(session, args.state)
+        for decision in _advance_bots(
+                session, bot, lambda: save_session(session, args.state)):
+            print(_format_decision(decision), flush=True)
+        print("\n" + render_position(session), flush=True)
+        return 0
+    if args.interactive:
+        return _interactive(session, args.state, bot)
+    print(render_position(session))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/hoyt/refsweep.py
+++ b/hoyt/refsweep.py
@@ -235,7 +235,8 @@ def _root_of(rd: dict):
 
 
 def solve_root(rec: dict, rung: Rung, rung_idx: int, cap: int,
-               oracle, threads: int | None = None) -> dict:
+               oracle, threads: int | None = None,
+               engine: str = "fused") -> dict:
     """One (root, rung) -> one ledger row. The pipeline mirrors the ad-hoc
     2026-07-18 sweep worker (enumerate_worlds -> sigma_consistent ->
     deterministic world cap -> build_subgame -> compile_sigma -> walt BR ->
@@ -286,7 +287,8 @@ def solve_root(rec: dict, rung: Rung, rung_idx: int, cap: int,
                         gap_exit=True,
                         wall_budget_s=rung.wall_budget_s,
                         slot_budget=rung.slot_budget,
-                        threads=threads)
+                        threads=threads if engine == "fused" else None,
+                        engine=engine)
         # the reference value IS the solve's self-play value (measured
         # identical on all 200 banked rows, delta 0.0); profile_value's
         # full stochastic re-walk survives only as a 1-in-20 audit (P9)
@@ -315,7 +317,16 @@ def solve_root(rec: dict, rung: Rung, rung_idx: int, cap: int,
             trace=[(i, round(g, 6)) for i, g in res.trace],
             timings={k: round(v, 2) for k, v in res.timings.items()},
             phase_s=ph,
+            engine=engine,
         )
+        root_dist = res.profile.get(root.me, int(sub.my0), ())
+        if root_dist is not None:
+            moves, probs = root_dist
+            order = np.argsort(np.asarray(probs), kind="stable")
+            top = int(order[-1])
+            second = float(probs[order[-2]]) if len(order) > 1 else 0.0
+            row["root_argmax"] = int(moves[top])
+            row["root_margin"] = round(float(probs[top]) - second, 9)
     except K.KernelMemoryError as e:
         row.update(verdict="slot_capped", error=repr(e)[:300])
     except Exception as e:  # noqa: BLE001 — every failure is a ledger row
@@ -348,7 +359,7 @@ def _worker_main(a) -> int:
             print(f"seed {seed} start "
                   f"(worlds_sigma={rec['n_worlds_sigma']})", flush=True)
             row = solve_root(rec, rung, a.worker_rung, a.cap, oracle,
-                             threads=a.threads or None)
+                             threads=a.threads or None, engine=a.engine)
             fh.write(json.dumps(row) + "\n")
             fh.flush()
             solved += 1
@@ -415,6 +426,14 @@ def _print_plan(recs, ledger, ladder, a) -> None:
 
 
 def _rung_workers(a, rung: Rung, n_entrants: int) -> int:
+    if a.engine == "metal":
+        # One process owns the unified Metal command stream. Root-fleet
+        # batching belongs inside that process; concurrent MLX workers merely
+        # contend for the same GPU and can exhaust unified memory.
+        if a.workers_explicit and a.workers != 1:
+            print("warning: --engine metal forces one worker until the "
+                  "root-batched scheduler lands", flush=True)
+        return min(1, n_entrants)
     mem_cap = default_workers(rung.slot_budget)
     if a.workers_explicit and a.workers > mem_cap:
         print(f"warning: --workers {a.workers} exceeds the memory-aware cap "
@@ -521,7 +540,7 @@ def _driver_main(a) -> int:
                    "--seeds", ",".join(map(str, queue)),
                    "--cap", str(a.cap), "--outdir", str(outdir),
                    "--evalset", str(evalset), "--net", a.net,
-                   "--threads", str(a.threads)]
+                   "--threads", str(a.threads), "--engine", a.engine]
             if a.rungs:
                 cmd += ["--rungs", a.rungs]
             procs.append(subprocess.Popen(cmd, stdout=log,
@@ -559,6 +578,9 @@ def main(argv=None) -> int:
                          "(P13; 0 = single-threaded kernels). Bitwise "
                          "identical either way; compose workers x threads "
                          "against the core budget")
+    ap.add_argument("--engine", choices=("fused", "metal"), default="fused",
+                    help="CFR iterate lane; calibrate metal with "
+                         "hoyt.metalcal before production use")
     ap.add_argument("--dry-run", action="store_true",
                     help="print ladder + resume state + shard plan, no solving")
     # worker mode (spawned by the driver; not a user surface)

--- a/hoyt/sampled_br.py
+++ b/hoyt/sampled_br.py
@@ -1,0 +1,799 @@
+"""Sparse external-sampling regret solving on Metal.
+
+This is the bounded-memory vertical slice for full-metal Hoyt. A traversal
+samples one exact hidden world, enumerates every action of the updating seat,
+and samples one current-policy action at the other seats. The public tree is
+never materialized: each microbatch holds only its current frontier and the
+parent maps required for one backward pass.
+
+The same traversal substrate supports two modes. ``SampledCFR`` alternates the
+updating seat through a shared sparse regret table to produce a four-seat
+candidate policy. ``SampledBR`` either starts from uniform opponents or forks
+that table, resets one seat, and learns a candidate best response while the
+other three seats stay frozen. Information sets live in a sorted sparse table
+keyed by seat plus a 62-bit fingerprint, so there are no direct-hash bucket
+collisions; the table also has a hard capacity and fails closed. The table is
+grown between frozen-policy microbatches; this first slice indexes sparse
+update records on the host before the reduced regret update returns to Metal.
+Moving that sort/merge onto the GPU is an explicit remaining production step.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+import hashlib
+import math
+from pathlib import Path
+
+import numpy as np
+
+from hoyt.subgame import build_subgame
+from hoyt.worldsample import WorldSampler
+
+try:
+    import mlx.core as mx
+except ImportError as exc:  # pragma: no cover
+    mx = None
+    _MLX_ERROR = exc
+else:
+    _MLX_ERROR = None
+
+__all__ = [
+    "SampledBR", "SampledBRResult", "SampledCFR", "SampledGapResult",
+    "SparsePolicy", "audit_sampled_gap",
+]
+
+_STRIDE = 12
+_PH0 = np.uint64(0xCBF29CE484222325)
+_PH_PRIME = 0x100000001B3
+_MASK64 = (1 << 64) - 1
+_MASK62 = (1 << 62) - 1
+
+
+def _mix64(value: int) -> int:
+    value &= _MASK64
+    value = ((value ^ (value >> 30)) * 0xBF58476D1CE4E5B9) & _MASK64
+    value = ((value ^ (value >> 27)) * 0x94D049BB133111EB) & _MASK64
+    return value ^ (value >> 31)
+
+
+def _info_key(seat: int, hand: int, path) -> np.uint64:
+    ph = int(_PH0)
+    for tile in path:
+        ph = (ph * _PH_PRIME + int(tile) + 1) & _MASK64
+    fingerprint = _mix64(ph ^ (int(hand) << 17)) & _MASK62
+    return np.uint64((int(seat) << 62) | fingerprint)
+
+
+def _root_signature(root) -> str:
+    return hashlib.sha256(repr(root).encode("utf-8")).hexdigest()
+
+
+def _bounded_mean_error(samples, low: float, high: float,
+                        alpha: float) -> float:
+    """Two-sided empirical-Bernstein radius for bounded iid observations."""
+    x = np.asarray(samples, dtype=np.float64).reshape(-1)
+    if len(x) < 2:
+        raise ValueError("bounded mean interval needs at least two samples")
+    if not 0.0 < alpha < 1.0:
+        raise ValueError("alpha must be between zero and one")
+    width = float(high) - float(low)
+    if width < 0.0 or not np.isfinite(width):
+        raise ValueError("payoff bounds must be finite and ordered")
+    logterm = math.log(2.0 / alpha)
+    variance = float(x.var(ddof=1))
+    return math.sqrt(2.0 * variance * logterm / len(x)) \
+        + 7.0 * width * logterm / (3.0 * (len(x) - 1))
+
+
+_COMMON = r"""
+inline ulong mix64(ulong z) {
+    z = (z ^ (z >> 30)) * 0xBF58476D1CE4E5B9ul;
+    z = (z ^ (z >> 27)) * 0x94D049BB133111EBul;
+    return z ^ (z >> 31);
+}
+
+inline uint tile_at_rank(uint mask, uint rank) {
+    for (uint t = 0; t < 28; ++t) {
+        if (mask & (1u << t)) {
+            if (rank == 0u) return t;
+            rank -= 1u;
+        }
+    }
+    return 31u;
+}
+
+inline ulong path_of(const device uint* state, uint i) {
+    return ((ulong)state[i * 12u + 11u] << 32)
+         | (ulong)state[i * 12u + 10u];
+}
+
+inline ulong info_key(const device uint* state, uint i, uint actor) {
+    uint hand = state[i * 12u + actor];
+    ulong fingerprint = mix64(path_of(state, i) ^ ((ulong)hand << 17));
+    return ((ulong)actor << 62)
+         | (fingerprint & 0x3FFFFFFFFFFFFFFFul);
+}
+
+inline uint legal_of(const device uint* state, uint i, uint actor,
+                     const device uint* cfb) {
+    uint hand = state[i * 12u + actor];
+    uint ledp = state[i * 12u + 5u];
+    if (ledp == 0u) return hand;
+    uint follow = hand & cfb[ledp - 1u];
+    return follow ? follow : hand;
+}
+"""
+
+_COUNT_SOURCE = r"""
+    uint i = thread_position_in_grid.x;
+    uint n = state_shape[0] / 12u;
+    if (i >= n) return;
+    uint leader = state[i * 12u + 4u];
+    uint actor = (leader + pos[0]) & 3u;
+    uint legal = legal_of(state, i, actor, cfb);
+    count[i] = actor == updater[0] ? popcount(legal) : 1u;
+"""
+
+_EXPAND_SOURCE = r"""
+    uint i = thread_position_in_grid.x;
+    uint n = state_shape[0] / 12u;
+    if (i >= n) return;
+    uint leader = state[i * 12u + 4u];
+    uint actor = (leader + pos[0]) & 3u;
+    uint legal = legal_of(state, i, actor, cfb);
+    uint nlegal = popcount(legal);
+    uint first = offset[i];
+    uint nchild = offset[i + 1u] - first;
+    uint chosen = 0u;
+    ulong ikey = info_key(state, i, actor);
+    uint lo = 0u;
+    uint hi = nkeys[0];
+    while (lo < hi) {
+        uint mid = lo + ((hi - lo) >> 1);
+        ulong probe = key_table[mid];
+        if (probe < ikey) lo = mid + 1u;
+        else hi = mid;
+    }
+    uint row = lo < nkeys[0] && key_table[lo] == ikey
+               ? lo : 0xFFFFFFFFu;
+
+    float total_pos = 0.0f;
+    if (row != 0xFFFFFFFFu) {
+        for (uint r = 0; r < nlegal; ++r)
+            total_pos += max(regret[row * 7u + r], 0.0f);
+    }
+
+    if (actor != updater[0]) {
+        // Independent counter stream per frontier parent. Path/hand keeps
+        // branches reproducible; i prevents a whole microbatch at the same
+        // information set from sharing one opponent draw.
+        ulong z = mix64(info_key(state, i, actor) ^ seed[0]
+                        ^ ((ulong)depth[0] << 48)
+                        ^ ((ulong)i * 0xD1B54A32D192ED03ul));
+        if (total_pos > 0.0f) {
+            float draw = (float)((z >> 40) & 0xFFFFFFul)
+                       * (total_pos / 16777216.0f);
+            float cumulative = 0.0f;
+            chosen = nlegal - 1u;
+            for (uint r = 0; r < nlegal; ++r) {
+                cumulative += max(regret[row * 7u + r], 0.0f);
+                if (draw < cumulative) {
+                    chosen = r;
+                    break;
+                }
+            }
+        } else {
+            chosen = (uint)(z % (ulong)nlegal);
+        }
+    }
+
+    for (uint q = 0; q < nchild; ++q) {
+        uint rank = actor == updater[0] ? q : chosen;
+        uint tile = tile_at_rank(legal, rank);
+        uint ci = first + q;
+        for (uint x = 0; x < 12u; ++x)
+            child[ci * 12u + x] = state[i * 12u + x];
+        child[ci * 12u + actor] &= ~(1u << tile);
+
+        uint ledp = state[i * 12u + 5u];
+        uint brankp = state[i * 12u + 6u];
+        uint bseatp = state[i * 12u + 7u];
+        uint tcnt = state[i * 12u + 8u];
+        uint points = state[i * 12u + 9u];
+        if (pos[0] == 0u) {
+            uint led = led_suit[tile];
+            child[ci * 12u + 5u] = led + 1u;
+            child[ci * 12u + 6u] = rank_lut[led * 28u + tile] + 1u;
+            child[ci * 12u + 7u] = actor + 1u;
+            child[ci * 12u + 8u] = count_lut[tile];
+        } else if (pos[0] < 3u) {
+            uint led = ledp - 1u;
+            uint rr = rank_lut[led * 28u + tile];
+            if (rr + 1u > brankp) {
+                child[ci * 12u + 6u] = rr + 1u;
+                child[ci * 12u + 7u] = actor + 1u;
+            }
+            child[ci * 12u + 8u] = tcnt + count_lut[tile];
+        } else {
+            uint led = ledp - 1u;
+            uint rr = rank_lut[led * 28u + tile];
+            uint winner = rr + 1u > brankp ? actor : bseatp - 1u;
+            uint award = tcnt + count_lut[tile] + 1u;
+            if ((winner & 1u) == bid_team[0]) points += award;
+            child[ci * 12u + 4u] = winner;
+            child[ci * 12u + 5u] = 0u;
+            child[ci * 12u + 6u] = 0u;
+            child[ci * 12u + 7u] = 0u;
+            child[ci * 12u + 8u] = 0u;
+            child[ci * 12u + 9u] = points;
+        }
+
+        ulong ph = path_of(state, i) * 0x100000001B3ul + (ulong)tile + 1ul;
+        child[ci * 12u + 10u] = (uint)ph;
+        child[ci * 12u + 11u] = (uint)(ph >> 32);
+        parent[ci] = i;
+        action_rank[ci] = rank;
+        if (actor == updater[0]) {
+            float rp = row == 0xFFFFFFFFu ? 0.0f
+                       : max(regret[row * 7u + rank], 0.0f);
+            probability[ci] = total_pos > 0.0f ? rp / total_pos
+                                                : 1.0f / (float)nlegal;
+        } else {
+            probability[ci] = 1.0f;
+        }
+    }
+"""
+
+_BACKWARD_SOURCE = r"""
+    uint i = thread_position_in_grid.x;
+    uint n = state_shape[0] / 12u;
+    if (i >= n) return;
+    uint leader = state[i * 12u + 4u];
+    uint actor = (leader + pos[0]) & 3u;
+    uint a = offset[i];
+    uint b = offset[i + 1u];
+    float value = 0.0f;
+    for (uint k = a; k < b; ++k) value += probability[k] * vchild[k];
+    vparent[i] = value;
+
+    uint e0 = i * 7u;
+    for (uint r = 0; r < 7u; ++r) {
+        event_index[e0 + r] = 0u;
+        event_delta[e0 + r] = 0.0f;
+        event_key_lo[e0 + r] = 0u;
+        event_key_hi[e0 + r] = 0u;
+    }
+    if (actor == updater[0]) {
+        ulong key = info_key(state, i, actor);
+        for (uint k = a; k < b; ++k) {
+            uint r = k - a;
+            event_index[e0 + r] = r;
+            event_delta[e0 + r] = sign[0] * (vchild[k] - value);
+            event_key_lo[e0 + r] = (uint)key;
+            event_key_hi[e0 + r] = (uint)(key >> 32);
+        }
+    }
+"""
+
+_REDUCE_SOURCE = r"""
+    uint i = thread_position_in_grid.x;
+    if (i >= event_delta_shape[0]) return;
+    float z = event_delta[i];
+    if (z != 0.0f)
+        atomic_fetch_add_explicit(&dense[event_index[i]], z,
+                                  memory_order_relaxed);
+"""
+
+_LEAF_SOURCE = r"""
+    uint i = thread_position_in_grid.x;
+    uint n = state_shape[0] / 12u;
+    if (i >= n) return;
+    value[i] = payoff[state[i * 12u + 9u]];
+"""
+
+
+@dataclass
+class SampledBRResult:
+    value: float
+    value_se: float
+    value_error: float
+    root_values: dict[int, float]
+    root_value_se: dict[int, float]
+    root_value_error: dict[int, float]
+    best_move: int | None
+    epochs: int
+    samples: int
+    table_capacity: int
+    occupied_buckets: int
+    key_collisions: int
+    peak_frontier: int
+
+
+@dataclass(frozen=True)
+class SparsePolicy:
+    """A frozen current-policy snapshot for one root.
+
+    Positive cumulative regrets define the action probabilities; rows with no
+    positive regret use the uniform fallback. Keys reserve their top two bits
+    for the acting seat and use a 62-bit information fingerprint below it.
+    """
+
+    root: object
+    keys: np.ndarray
+    regret: np.ndarray
+
+    def dist(self, seat: int, hand: int, path, legal_moves):
+        """Return a sparse regret-matched distribution, uniform if unseen."""
+        moves = np.sort(np.asarray(legal_moves, dtype=np.int64).reshape(-1))
+        if not len(moves):
+            raise ValueError("legal_moves must be nonempty")
+        key = _info_key(seat, hand, path)
+        row = int(np.searchsorted(self.keys, key))
+        if row < len(self.keys) and self.keys[row] == key:
+            positive = np.maximum(self.regret[row, :len(moves)], 0.0) \
+                .astype(np.float64)
+            total = float(positive.sum())
+            if total > 0.0:
+                return moves, positive / total
+        return moves, np.full(len(moves), 1.0 / len(moves))
+
+    def save(self, path) -> None:
+        """Write a compact candidate-policy artifact for this exact root."""
+        np.savez_compressed(
+            Path(path), keys=self.keys, regret=self.regret,
+            root_signature=np.asarray(_root_signature(self.root)),
+            format_version=np.asarray(1, dtype=np.int64))
+
+    @classmethod
+    def load(cls, root, path):
+        with np.load(Path(path), allow_pickle=False) as data:
+            if int(data["format_version"].item()) != 1:
+                raise ValueError("unsupported sparse policy artifact version")
+            signature = str(data["root_signature"].item())
+            if signature != _root_signature(root):
+                raise ValueError("sparse policy artifact belongs to another root")
+            return cls(root, data["keys"].copy(), data["regret"].copy())
+
+
+@dataclass
+class SampledGapResult:
+    profile_value: float
+    profile_value_se: float
+    candidate_gains: dict[int, float]
+    candidate_gain_se: dict[int, float]
+    candidate_gain_error: dict[int, float]
+    gap_lower: float
+    candidate_gap_upper: float
+    gap_upper: float
+    shortfall_upper: float | None
+    candidate_coverage: float
+    gap_coverage: float | None
+    verdict: str
+
+
+class SampledBR:
+    """Candidate best response to uniform or frozen sparse opponents."""
+
+    def __init__(self, root, payoff43, capacity: int = 1 << 20,
+                 updater: int | None = None,
+                 frozen_policy: SparsePolicy | None = None):
+        if mx is None:
+            raise RuntimeError("SampledBR requires MLX") from _MLX_ERROR
+        if capacity <= 0:
+            raise ValueError("capacity must be positive")
+        self.root = root
+        self.sampler = WorldSampler.from_root(root)
+        self.capacity = int(capacity)
+        payoff = np.asarray(payoff43, dtype=np.float32).reshape(-1)
+        if len(payoff) != 43:
+            raise ValueError("payoff43 must have 43 entries")
+        self.payoff_np = payoff.copy()
+        self.payoff = mx.array(payoff)
+        # A one-world subgame is enough to parse the root and rule tables.
+        sub = build_subgame(root, self.sampler.sample(1), np.ones(1))
+        self.sub = sub
+        self.updater = int(root.me if updater is None else updater)
+        if not 0 <= self.updater < 4:
+            raise ValueError("updater must be a seat in 0..3")
+        self.sign = 1 if self.updater % 2 == sub.bid_team else -1
+        if frozen_policy is None:
+            keys = np.empty(0, dtype=np.uint64)
+            regret = np.empty((0, 7), dtype=np.float32)
+        else:
+            if frozen_policy.root != root:
+                raise ValueError("frozen policy belongs to a different root")
+            keys = np.asarray(frozen_policy.keys, dtype=np.uint64).reshape(-1)
+            regret = np.asarray(frozen_policy.regret, dtype=np.float32)
+            if regret.shape != (len(keys), 7):
+                raise ValueError("frozen policy regret must have shape (N, 7)")
+            if len(keys) > self.capacity:
+                raise MemoryError(
+                    f"frozen policy has {len(keys):,} rows > capacity "
+                    f"{self.capacity:,}")
+            if len(keys) > 1 and (keys[1:] <= keys[:-1]).any():
+                raise ValueError("frozen policy keys must be strictly sorted")
+            regret = regret.copy()
+            # This seat is the new BR candidate; the other three rows remain
+            # the frozen opponent policy inherited from the CFR snapshot.
+            regret[(keys >> np.uint64(62)) == self.updater] = 0.0
+        self.keys_np = keys.copy()
+        self.key_table = mx.array(
+            self.keys_np if len(self.keys_np) else np.zeros(1, np.uint64))
+        self.nkeys = mx.array([len(self.keys_np)], dtype=mx.uint32)
+        # Only the occupied prefix is meaningful. Seven elements let the
+        # first previously unseen information set follow the same growth path.
+        initial = regret.reshape(-1) if len(regret) else np.zeros(7, np.float32)
+        self.regret = mx.array(initial)
+        self._scalar = {
+            "bid_team": mx.array([sub.bid_team], dtype=mx.uint32),
+        }
+        self._updater = {u: mx.array([u], dtype=mx.uint32) for u in range(4)}
+        self._sign = {
+            u: mx.array([1.0 if u % 2 == sub.bid_team else -1.0],
+                        dtype=mx.float32)
+            for u in range(4)
+        }
+        self.cfb = mx.array(sub.luts.can_follow_bits.astype(np.uint32))
+        self.led_suit = mx.array(sub.luts.led_suit.astype(np.uint32))
+        self.rank = mx.array(sub.luts.rank.astype(np.uint32).reshape(-1))
+        self.count = mx.array(sub.luts.count.astype(np.uint32))
+        self._count_kernel = mx.fast.metal_kernel(
+            name="hoyt_es_count", input_names=["state", "cfb", "pos",
+            "updater"], output_names=["count"], source=_COUNT_SOURCE,
+            header=_COMMON)
+        self._expand_kernel = mx.fast.metal_kernel(
+            name="hoyt_es_expand", input_names=["state", "offset", "regret",
+            "cfb", "led_suit", "rank_lut", "count_lut", "pos", "updater",
+            "key_table", "nkeys", "seed", "depth", "bid_team"],
+            output_names=["child", "parent", "probability", "action_rank"],
+            source=_EXPAND_SOURCE, header=_COMMON)
+        self._backward_kernel = mx.fast.metal_kernel(
+            name="hoyt_es_backward", input_names=["state", "offset",
+            "probability", "vchild", "pos", "updater", "sign"],
+            output_names=["vparent", "event_index", "event_delta",
+            "event_key_lo", "event_key_hi"], source=_BACKWARD_SOURCE,
+            header=_COMMON)
+        self._reduce_kernel = mx.fast.metal_kernel(
+            name="hoyt_es_reduce", input_names=["event_index", "event_delta"],
+            output_names=["dense"], source=_REDUCE_SOURCE,
+            atomic_outputs=True)
+        self._leaf_kernel = mx.fast.metal_kernel(
+            name="hoyt_es_leaf", input_names=["state", "payoff"],
+            output_names=["value"], source=_LEAF_SOURCE)
+        self.epochs = 0
+        self.samples = 0
+        self.peak_frontier = 0
+        # This reports direct-table collisions, which the sorted table cannot
+        # have. The 62-bit information fingerprint itself is probabilistic.
+        self.key_collisions = 0
+
+    @staticmethod
+    def _call(kernel, inputs, n, shapes, dtypes, **kw):
+        return kernel(inputs=inputs, grid=(n, 1, 1),
+                      threadgroup=(min(256, n), 1, 1),
+                      output_shapes=shapes, output_dtypes=dtypes, **kw)
+
+    def _initial_state(self, worlds):
+        worlds = np.asarray(worlds, dtype=np.uint32).reshape(-1, 3)
+        n = len(worlds)
+        state = np.zeros((n, _STRIDE), dtype=np.uint32)
+        state[:, int(self.root.me)] = np.uint32(self.sub.my0)
+        for col, seat in enumerate(self.sampler.seats):
+            state[:, seat] = worlds[:, col]
+        state[:, 4] = np.uint32(self.sub.leader0)
+        state[:, 5] = np.uint32(self.sub.led0 + 1)
+        state[:, 6] = np.uint32(self.sub.brank0 + 1)
+        state[:, 7] = np.uint32(self.sub.bseat0 + 1)
+        state[:, 8] = np.uint32(self.sub.cnt0)
+        state[:, 9] = np.uint32(self.sub.ptsv0)
+        state[:, 10] = np.uint32(int(_PH0) & 0xFFFFFFFF)
+        state[:, 11] = np.uint32(int(_PH0) >> 32)
+        return mx.array(state.reshape(-1))
+
+    def _traverse(self, worlds, seed: int, updater: int | None = None):
+        updater = self.updater if updater is None else int(updater)
+        if not 0 <= updater < 4:
+            raise ValueError("updater must be a seat in 0..3")
+        state = self._initial_state(worlds)
+        states = []
+        transitions = []
+        depth_n = 28 - self.sub.p0
+        for depth in range(depth_n):
+            n = int(state.shape[0]) // _STRIDE
+            self.peak_frontier = max(self.peak_frontier, n)
+            pos = mx.array([(self.sub.p0 + depth) & 3], dtype=mx.uint32)
+            count, = self._call(
+                self._count_kernel,
+                [state, self.cfb, pos, self._updater[updater]], n,
+                [(n,)], [mx.uint32])
+            offset = mx.concatenate(
+                [mx.zeros((1,), dtype=mx.uint32), mx.cumsum(count)])
+            total = int(offset[-1].item())
+            child, _parent, probability, _rank = self._call(
+                self._expand_kernel,
+                [state, offset, self.regret, self.cfb, self.led_suit,
+                 self.rank, self.count, pos, self._updater[updater],
+                 self.key_table, self.nkeys,
+                 mx.array([seed & ((1 << 64) - 1)], dtype=mx.uint64),
+                 mx.array([depth], dtype=mx.uint32),
+                 self._scalar["bid_team"]],
+                n, [(total * _STRIDE,), (total,), (total,), (total,)],
+                [mx.uint32, mx.uint32, mx.float32, mx.uint32])
+            states.append(state)
+            transitions.append((offset, probability, pos))
+            state = child
+
+        nleaf = int(state.shape[0]) // _STRIDE
+        value, = self._call(self._leaf_kernel, [state, self.payoff], nleaf,
+                            [(nleaf,)], [mx.float32])
+        event_i = []
+        event_d = []
+        event_lo = []
+        event_hi = []
+        root_q = None
+        for depth in range(depth_n - 1, -1, -1):
+            pstate = states[depth]
+            offset, probability, pos = transitions[depth]
+            n = int(pstate.shape[0]) // _STRIDE
+            if depth == 0:
+                root_q = value
+            value, ei, ed, klo, khi = self._call(
+                self._backward_kernel,
+                [pstate, offset, probability, value, pos,
+                 self._updater[updater], self._sign[updater]],
+                n, [(n,), (n * 7,), (n * 7,), (n * 7,), (n * 7,)],
+                [mx.float32, mx.uint32, mx.float32, mx.uint32, mx.uint32])
+            event_i.append(ei)
+            event_d.append(ed)
+            event_lo.append(klo)
+            event_hi.append(khi)
+        return value, root_q, mx.concatenate(event_i), \
+            mx.concatenate(event_d), mx.concatenate(event_lo), \
+            mx.concatenate(event_hi)
+
+    def _apply_events(self, action, delta, key_lo, key_hi, batch_size):
+        mx.eval(action, delta, key_lo, key_hi)
+        act = np.asarray(action, dtype=np.uint32)
+        d = np.asarray(delta, dtype=np.float32)
+        lo = np.asarray(key_lo, dtype=np.uint32)
+        hi = np.asarray(key_hi, dtype=np.uint32)
+        valid = d != 0.0
+        if not valid.any():
+            return
+        act = act[valid]
+        d = d[valid]
+        keys = lo[valid].astype(np.uint64) \
+            | (hi[valid].astype(np.uint64) << np.uint64(32))
+        merged = np.union1d(self.keys_np, np.unique(keys))
+        if len(merged) > self.capacity:
+            raise MemoryError(
+                f"sampled information table needs {len(merged):,} rows "
+                f"> capacity {self.capacity:,}; reschedule with a larger slab")
+        if len(merged) != len(self.keys_np):
+            old = np.asarray(self.regret, dtype=np.float32) \
+                .reshape(-1, 7)[:len(self.keys_np)]
+            grown = np.zeros((max(1, len(merged)), 7), dtype=np.float32)
+            if len(self.keys_np):
+                grown[np.searchsorted(merged, self.keys_np)] = old
+            self.keys_np = merged
+            self.key_table = mx.array(
+                merged if len(merged) else np.zeros(1, dtype=np.uint64))
+            self.nkeys = mx.array([len(merged)], dtype=mx.uint32)
+            self.regret = mx.array(grown.reshape(-1))
+        row = np.searchsorted(self.keys_np, keys).astype(np.uint32)
+        flat = row * np.uint32(7) + act
+        ne = len(d)
+        dense, = self._reduce_kernel(
+            inputs=[mx.array(flat), mx.array(d)],
+            grid=(ne, 1, 1), threadgroup=(min(256, ne), 1, 1),
+            output_shapes=[(max(1, len(self.keys_np)) * 7,)],
+            output_dtypes=[mx.float32], init_value=0.0)
+        self.regret = self.regret + dense / np.float32(batch_size)
+        mx.eval(self.regret)
+
+    def snapshot(self) -> SparsePolicy:
+        """Freeze the current regret-matched policy on the host boundary."""
+        mx.eval(self.regret)
+        regret = np.asarray(self.regret, dtype=np.float32) \
+            .reshape(-1, 7)[:len(self.keys_np)].copy()
+        return SparsePolicy(self.root, self.keys_np.copy(), regret)
+
+    def train(self, epochs: int, batch_size: int, seed: int = 0):
+        """Run frozen-policy external-sampling microbatches."""
+        if epochs < 0 or batch_size <= 0:
+            raise ValueError("epochs must be nonnegative and batch_size positive")
+        for e in range(epochs):
+            worlds = self.sampler.sample_metal(batch_size,
+                                               seed + self.epochs + e)
+            _v, _q, event_i, event_d, key_lo, key_hi = self._traverse(
+                worlds, seed + self.epochs + e)
+            self._apply_events(event_i, event_d, key_lo, key_hi, batch_size)
+            self.samples += batch_size
+        self.epochs += epochs
+        return self
+
+    def evaluate(self, batches: int, batch_size: int, seed: int = 1_000_000,
+                 alpha: float = 0.05):
+        if batches <= 0 or batch_size <= 0 or batches * batch_size < 2:
+            raise ValueError("evaluation needs at least two samples")
+        values = []
+        qrows = []
+        for b in range(batches):
+            worlds = self.sampler.sample_metal(batch_size, seed + b)
+            value, root_q, _ei, _ed, _lo, _hi = self._traverse(
+                worlds, seed + b)
+            mx.eval(value, root_q)
+            values.append(np.asarray(value, dtype=np.float64))
+            if self.updater == int(self.root.me):
+                nlegal = int(root_q.shape[0]) // batch_size
+                qrows.append(np.asarray(root_q, dtype=np.float64)
+                             .reshape(batch_size, nlegal))
+        val = np.concatenate(values)
+        vm = float(val.mean())
+        vse = float(val.std(ddof=1) / np.sqrt(len(val)))
+        verr = _bounded_mean_error(
+            val, float(self.payoff_np.min()), float(self.payoff_np.max()),
+            alpha)
+        root_values = {}
+        root_value_se = {}
+        root_value_error = {}
+        best_move = None
+        if qrows:
+            q = np.concatenate(qrows)
+            qm = q.mean(axis=0)
+            qse = q.std(axis=0, ddof=1) / np.sqrt(len(q))
+            legal = []
+            mask = int(self.sub.my0)
+            led = self.sub.led0
+            if led >= 0:
+                follow = mask & int(self.sub.luts.can_follow_bits[led])
+                if follow:
+                    mask = follow
+            while mask:
+                bit = mask & -mask
+                legal.append(bit.bit_length() - 1)
+                mask ^= bit
+            if len(legal) != len(qm):
+                raise AssertionError("root action/value layout mismatch")
+            orient = self.sign * qm
+            best = int(np.argmax(orient))
+            root_values = {m: float(qm[i]) for i, m in enumerate(legal)}
+            root_value_se = {m: float(qse[i]) for i, m in enumerate(legal)}
+            root_value_error = {
+                m: _bounded_mean_error(
+                    q[:, i], float(self.payoff_np.min()),
+                    float(self.payoff_np.max()), alpha / len(legal))
+                for i, m in enumerate(legal)
+            }
+            best_move = legal[best]
+        return SampledBRResult(
+            value=vm,
+            value_se=vse,
+            value_error=verr,
+            root_values=root_values,
+            root_value_se=root_value_se,
+            root_value_error=root_value_error,
+            best_move=best_move,
+            epochs=self.epochs,
+            samples=self.samples,
+            table_capacity=self.capacity,
+            occupied_buckets=len(self.keys_np),
+            key_collisions=self.key_collisions,
+            peak_frontier=self.peak_frontier,
+        )
+
+
+class SampledCFR(SampledBR):
+    """Shared-table four-seat external-sampling CFR candidate learner.
+
+    One epoch performs one frozen-policy microbatch for each updating seat in
+    seat order. The exported policy is the current ordinary-regret-matching
+    policy. It is a candidate whose exploitability must be audited; no
+    last-iterate equilibrium theorem is claimed.
+    """
+
+    def train(self, epochs: int, batch_size: int, seed: int = 0):
+        if epochs < 0 or batch_size <= 0:
+            raise ValueError("epochs must be nonnegative and batch_size positive")
+        for e in range(epochs):
+            epoch = self.epochs + e
+            for updater in range(4):
+                stream = seed + epoch * 4 + updater
+                worlds = self.sampler.sample_metal(batch_size, stream)
+                _v, _q, event_i, event_d, key_lo, key_hi = self._traverse(
+                    worlds, stream, updater=updater)
+                self._apply_events(event_i, event_d, key_lo, key_hi,
+                                   batch_size)
+                self.samples += batch_size
+        self.epochs += epochs
+        return self
+
+    def fork_best_response(self, updater: int,
+                           capacity: int | None = None) -> SampledBR:
+        """Freeze this candidate and reset one seat into a BR learner."""
+        return SampledBR(
+            self.root, self.payoff_np,
+            capacity=self.capacity if capacity is None else capacity,
+            updater=updater, frozen_policy=self.snapshot())
+
+
+def audit_sampled_gap(cfr: SampledCFR, br_epochs: int, train_batch: int,
+                      eval_batches: int, eval_batch: int,
+                      seed: int = 2_000_000,
+                      shortfall_upper: float | None = None,
+                      shortfall_alpha: float | None = None,
+                      target_gap: float = 0.05,
+                      alpha: float = 0.05) -> SampledGapResult:
+    """Train independent per-seat candidate BRs and price a sampled gap.
+
+    Without a calibrated ``shortfall_upper`` the candidate BRs still prove a
+    lower bound on exploitability, but cannot prove convergence; the returned
+    upper bound is therefore infinite and the verdict is ``unresolved`` unless
+    the lower bound already proves ``not_converged``. With a finite shortfall,
+    ``shortfall_alpha`` is mandatory so candidate and calibration miscoverage
+    can be union-bounded to the requested total ``alpha``.
+    """
+    if not 0.0 < alpha < 1.0:
+        raise ValueError("alpha must be between zero and one")
+    if shortfall_upper is None:
+        if shortfall_alpha is not None:
+            raise ValueError("shortfall_alpha requires shortfall_upper")
+        candidate_alpha = alpha
+        gap_coverage = None
+    else:
+        if shortfall_alpha is None or not 0.0 < shortfall_alpha < alpha:
+            raise ValueError(
+                "finite shortfall needs 0 < shortfall_alpha < alpha")
+        candidate_alpha = alpha - shortfall_alpha
+        gap_coverage = 1.0 - alpha
+
+    # Five mean estimates (one baseline, four candidate BRs) split the
+    # candidate budget. A second union bound combines that simultaneous band
+    # with the independently calibrated optimization-shortfall budget.
+    mean_alpha = candidate_alpha / 5.0
+    baseline = cfr.evaluate(eval_batches, eval_batch, seed=seed,
+                            alpha=mean_alpha)
+    gains = {}
+    ses = {}
+    errors = {}
+    bid_team = int(cfr.sub.bid_team)
+    for updater in range(4):
+        br = cfr.fork_best_response(updater)
+        br.train(br_epochs, train_batch, seed=seed + 10_000 * (updater + 1))
+        got = br.evaluate(eval_batches, eval_batch,
+                          seed=seed + 100_000 + 10_000 * updater,
+                          alpha=mean_alpha)
+        sign = 1.0 if updater % 2 == bid_team else -1.0
+        gains[updater] = sign * (got.value - baseline.value)
+        ses[updater] = float(np.hypot(got.value_se, baseline.value_se))
+        errors[updater] = got.value_error + baseline.value_error
+
+    lower = max(0.0, max(gains[u] - errors[u] for u in range(4)))
+    candidate_upper = max(0.0,
+                          max(gains[u] + errors[u] for u in range(4)))
+    if shortfall_upper is None:
+        upper = float("inf")
+    else:
+        if shortfall_upper < 0 or not np.isfinite(shortfall_upper):
+            raise ValueError("shortfall_upper must be finite and nonnegative")
+        upper = candidate_upper + float(shortfall_upper)
+    if lower > target_gap:
+        verdict = "not_converged"
+    elif upper <= target_gap:
+        verdict = "converged"
+    else:
+        verdict = "unresolved"
+    return SampledGapResult(
+        profile_value=baseline.value,
+        profile_value_se=baseline.value_se,
+        candidate_gains=gains,
+        candidate_gain_se=ses,
+        candidate_gain_error=errors,
+        gap_lower=lower,
+        candidate_gap_upper=candidate_upper,
+        gap_upper=upper,
+        shortfall_upper=shortfall_upper,
+        candidate_coverage=1.0 - candidate_alpha,
+        gap_coverage=gap_coverage,
+        verdict=verdict,
+    )

--- a/hoyt/tests/test_cfr_metal.py
+++ b/hoyt/tests/test_cfr_metal.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python
+"""Metal CFR smoke, accuracy, and calibration-contract gates."""
+from __future__ import annotations
+
+import sys
+
+import numpy as np
+
+from hoyt import reference as ref
+from hoyt import toys as T
+from hoyt.cfr import cfr_solve
+from hoyt.metalcal import (br_shortfall_upper, calibrated_gap_interval,
+                           calibration_report, conformal_upper)
+from hoyt.metalkernel import metal_available
+
+_failures = []
+
+
+def _gate(ok, name, detail=""):
+    print(f"{'PASS' if ok else 'FAIL'} {name}"
+          f"{(' — ' + detail) if detail else ''}")
+    if not ok:
+        _failures.append(name)
+
+
+def gate_M1():
+    _gate(metal_available(), "M1 MLX Metal GPU is available")
+
+
+def gate_M2():
+    worst_v = worst_g = worst_p = 0.0
+    for name in ("t2_decl_w3", "t2_def_w3", "t2_decl_w12", "t2_def_w12"):
+        sub = T.get_toy(name).build()
+        kw = dict(iters=60, br_every=20, impl=ref)
+        cpu = cfr_solve(sub, T.payoff_points(), engine="fused", **kw)
+        gpu = cfr_solve(sub, T.payoff_points(), engine="metal", **kw)
+        worst_v = max(worst_v, abs(cpu.value - gpu.value))
+        worst_g = max(worst_g, abs(cpu.gap - gpu.gap))
+        for key in cpu.profile.entries:
+            worst_p = max(worst_p, float(np.max(np.abs(
+                cpu.profile.entries[key][1]
+                - gpu.profile.entries[key][1]))))
+    ok = worst_v <= 1e-5 and worst_g <= 1e-5 and worst_p <= 1e-5
+    _gate(ok, "M2 float32 Metal agrees on calibration toys",
+          f"value {worst_v:.2e}, gap {worst_g:.2e}, policy {worst_p:.2e}")
+
+
+def gate_M3():
+    errors = np.arange(1, 21, dtype=float)
+    bar = conformal_upper(errors, 0.95)
+    cal = [(i, {"cfr_reference_value": 0, "final_gap": 0.01},
+            {"cfr_reference_value": i / 1000,
+             "final_gap": 0.01 + i / 10000})
+           for i in range(1, 21)]
+    hold = [(100 + i,
+             {"cfr_reference_value": 1, "final_gap": 0.02,
+              "root_margin": 0.1, "root_argmax": 4},
+             {"cfr_reference_value": 1.005, "final_gap": 0.021,
+              "root_argmax": 4}) for i in range(4)]
+    report = calibration_report(cal, hold, 0.95, 0.05)
+    shortfall = br_shortfall_upper(np.arange(20) / 100,
+                                   np.arange(20) / 100 - 0.01, 0.95)
+    lo, hi = calibrated_gap_interval([0.02, 0.03, 0.01, 0.0],
+                                     [0.001] * 4, shortfall)
+    ok = bar == 20.0 and report["value"]["heldout_covered"] == 4 \
+        and report["convergence"]["wrong_when_certain"] == 0 \
+        and abs(shortfall - 0.01) < 1e-12 and lo < 0.03 < hi
+    _gate(ok, "M3 conformal error-bar contract", f"rank bar {bar:g}")
+
+
+def main():
+    gate_M1()
+    gate_M2()
+    gate_M3()
+    if _failures:
+        print(f"\n{len(_failures)} gate(s) FAILED: {_failures}")
+        return 1
+    print("\nall Metal CFR gates green")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/hoyt/tests/test_play.py
+++ b/hoyt/tests/test_play.py
@@ -1,0 +1,86 @@
+"""Information-boundary and session tests for the playable Hoyt adapter."""
+from __future__ import annotations
+
+from dataclasses import replace
+
+from arena.play import RandomPlay
+from forge.zeb.game import apply_action, current_player, legal_actions
+from forge.zeb.types import GamePhase
+from hoyt.play import (
+    HoytPlay,
+    SolveBudget,
+    TableSession,
+    _action_from_text,
+    advance_to_horizon,
+    format_domino,
+    load_session,
+    render_position,
+    root_from_state,
+    save_session,
+)
+
+
+def _h5_state(seed: int = 910001):
+    return advance_to_horizon(seed, 5, RandomPlay(123))
+
+
+def test_root_projection_ignores_referee_hidden_hands():
+    state = _h5_state()
+    me = current_player(state)
+    hidden = [s for s in range(4) if s != me]
+    hands = [list(h) for h in state.hands]
+    # Swap two still-hidden, unplayed tiles.  The synthetic referee state need
+    # not be a reachable prefix: the point of this unit gate is that projection
+    # cannot observe either hidden holding at all.
+    a = next(d for d in hands[hidden[0]] if d not in state.played)
+    b = next(d for d in hands[hidden[1]] if d not in state.played)
+    ia = hands[hidden[0]].index(a)
+    ib = hands[hidden[1]].index(b)
+    hands[hidden[0]][ia], hands[hidden[1]][ib] = b, a
+    altered = replace(state, hands=tuple(tuple(h) for h in hands))
+    assert root_from_state(state) == root_from_state(altered)
+
+
+def test_table_session_round_trip_and_render_hide_other_hands(tmp_path):
+    state = _h5_state()
+    session = TableSession(
+        state=state, human_seat=current_player(state), seed=910001,
+        start_horizon=5, prefix="random")
+    path = tmp_path / "session.json"
+    save_session(session, path)
+    loaded = load_session(path)
+    assert loaded == session
+
+    rendered = render_position(loaded)
+    me = loaded.human_seat
+    for seat in range(4):
+        if seat == me:
+            continue
+        for tile in loaded.state.hands[seat]:
+            if tile not in loaded.state.played:
+                assert format_domino(tile) not in rendered
+
+
+def test_displayed_choice_and_domino_text_resolve_to_same_legal_action():
+    state = _h5_state()
+    legal = legal_actions(state)
+    first = int(legal[0])
+    tile = state.hands[current_player(state)][first]
+    assert _action_from_text(state, "1") == first
+    assert _action_from_text(state, format_domino(tile)) == first
+    assert _action_from_text(state, format_domino(tile).replace("-", "")) == first
+
+
+def test_forced_play_does_not_construct_a_solver():
+    state = _h5_state()
+    # Advance with legal first actions until a forced position appears.  Late
+    # in every hand the acting seat has one tile, so this is deterministic.
+    while state.phase == GamePhase.PLAYING and len(legal_actions(state)) != 1:
+        state = apply_action(state, legal_actions(state)[0])
+    assert state.phase == GamePhase.PLAYING
+    player = HoytPlay(
+        budgets={h: SolveBudget(0, 1, 1, 2, capacity=1) for h in range(1, 7)})
+    got = player.choose([state], [state.bid_state.high_bid])
+    assert got == [legal_actions(state)[0]]
+    assert player.last_decisions[0].forced
+    assert player.last_decisions[0].wall_seconds == 0.0

--- a/hoyt/tests/test_sampled_br.py
+++ b/hoyt/tests/test_sampled_br.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python
+"""Bounded-memory external-sampling BR gates."""
+from __future__ import annotations
+
+import sys
+import tempfile
+from pathlib import Path
+
+import numpy as np
+
+import hoyt as K
+from hoyt import toys as T
+from hoyt.cfr import cfr_solve
+from hoyt.sampled_br import SampledBR, SampledCFR, audit_sampled_gap
+from walt.worlds import enumerate_worlds
+
+_failures = []
+
+
+def _gate(ok, name, detail=""):
+    print(f"{'PASS' if ok else 'FAIL'} {name}"
+          f"{(' — ' + detail) if detail else ''}")
+    if not ok:
+        _failures.append(name)
+
+
+def gate_S1():
+    root, worlds = T.gen_engine_root(23, 3)
+    sub = K.build_subgame(root, worlds,
+                          np.full(len(worlds), 1.0 / len(worlds)))
+    exact = K.br_solve(sub, K.StochasticProfile(uniform_fallback=True),
+                       K.payoff_points(), hero=root.me)
+    solver = SampledBR(root, K.payoff_points(), capacity=1 << 18)
+    solver.train(epochs=300, batch_size=128, seed=20)
+    got = solver.evaluate(batches=30, batch_size=512, seed=100_000)
+    z = abs(got.value - exact.value) / got.value_se
+    ok = (got.best_move == exact.best_move and z < 4.0
+          and abs(got.value - exact.value) <= got.value_error
+          and got.key_collisions == 0
+          and got.occupied_buckets < got.table_capacity)
+    _gate(ok, "S1 sampled Metal BR covers exact H3 BR",
+          f"move {got.best_move}/{exact.best_move}, |z| {z:.2f}, "
+          f"rows {got.occupied_buckets:,}, peak {got.peak_frontier:,}")
+
+
+def gate_S2():
+    root = T.get_toy("t2_decl_w12").root
+    solver = SampledBR(root, K.payoff_points(), capacity=1 << 14)
+    solver.train(epochs=100, batch_size=64, seed=10)
+    got = solver.evaluate(batches=20, batch_size=256, seed=100_000)
+    exact_worlds = enumerate_worlds(root)
+    exact_sub = K.build_subgame(
+        root, exact_worlds, np.full(len(exact_worlds), 1.0 / len(exact_worlds)))
+    exact = K.br_solve(exact_sub,
+                       K.StochasticProfile(uniform_fallback=True),
+                       K.payoff_points(), hero=root.me)
+    ok = got.best_move == exact.best_move \
+        and abs(got.value - exact.value) <= got.value_error
+    _gate(ok, "S2 sampled BR reproducible on enumerable H2",
+          f"value {got.value:.4f}, EB ±{got.value_error:.4f}, "
+          f"exact {exact.value:.4f}")
+
+
+def gate_S3():
+    root, _ = T.gen_engine_root(23, 3)
+    solver = SampledBR(root, K.payoff_points(), capacity=16)
+    try:
+        solver.train(epochs=2, batch_size=64, seed=5)
+    except MemoryError:
+        ok = True
+    else:
+        ok = False
+    _gate(ok, "S3 sparse-table capacity fails closed")
+
+
+def gate_S4():
+    root = T.get_toy("t2_decl_w12").root
+    worlds = enumerate_worlds(root)
+    sub = K.build_subgame(
+        root, worlds, np.full(len(worlds), 1.0 / len(worlds)))
+    exact = cfr_solve(sub, K.payoff_points(), iters=300, br_every=50)
+    solver = SampledCFR(root, K.payoff_points(), capacity=1 << 17)
+    solver.train(epochs=300, batch_size=64, seed=30)
+    got = solver.evaluate(batches=30, batch_size=512, seed=700_000)
+
+    policy = solver.snapshot()
+    mask = int(solver.sub.my0)
+    legal = [tile for tile in range(28) if mask & (1 << tile)]
+    moves, probs = policy.dist(root.me, mask, (), legal)
+    with tempfile.TemporaryDirectory() as tmp:
+        artifact = Path(tmp) / "policy.npz"
+        policy.save(artifact)
+        loaded = type(policy).load(root, artifact)
+        artifact_ok = np.array_equal(loaded.keys, policy.keys) \
+            and np.array_equal(loaded.regret, policy.regret)
+    actors = set((policy.keys >> np.uint64(62)).astype(int).tolist())
+    fork = solver.fork_best_response(root.me)
+    forked = fork.snapshot()
+    hero = (policy.keys >> np.uint64(62)) == int(root.me)
+    frozen_ok = np.array_equal(forked.keys, policy.keys) \
+        and np.all(forked.regret[hero] == 0.0) \
+        and np.array_equal(forked.regret[~hero], policy.regret[~hero])
+    audit = audit_sampled_gap(
+        solver, br_epochs=20, train_batch=32,
+        eval_batches=5, eval_batch=128, seed=800_000)
+    try:
+        audit_sampled_gap(
+            solver, br_epochs=0, train_batch=32,
+            eval_batches=1, eval_batch=2, shortfall_upper=0.0)
+    except ValueError:
+        split_ok = True
+    else:
+        split_ok = False
+    z = abs(got.value - exact.value) / got.value_se
+    ok = split_ok and artifact_ok \
+        and np.array_equal(moves, np.asarray(legal)) \
+        and abs(float(probs.sum()) - 1.0) < 1e-12 \
+        and not np.allclose(probs, 1.0 / len(probs)) \
+        and actors == {0, 1, 2, 3} and frozen_ok and z < 4.0 \
+        and abs(got.value - exact.value) <= got.value_error \
+        and audit.verdict == "unresolved" \
+        and np.isfinite(audit.candidate_gap_upper) \
+        and np.isinf(audit.gap_upper)
+    _gate(ok, "S4 four-seat CFR and frozen-policy BR fork",
+          f"value |z| {z:.2f}, rows {len(policy.keys):,}, "
+          f"actors {sorted(actors)}, audit {audit.verdict}")
+
+
+def main():
+    gate_S1()
+    gate_S2()
+    gate_S3()
+    gate_S4()
+    if _failures:
+        print(f"\n{len(_failures)} gate(s) FAILED: {_failures}")
+        return 1
+    print("\nall sampled-BR gates green")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/hoyt/tests/test_worldsample.py
+++ b/hoyt/tests/test_worldsample.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python
+"""Exact DP world-sampler gates, including the Metal path."""
+from __future__ import annotations
+
+import sys
+
+import numpy as np
+
+from hoyt import toys as T
+from hoyt.worldsample import WorldSampler
+from walt.contracts import EndgameRoot
+from walt.worlds import enumerate_worlds
+
+_failures = []
+
+
+def _gate(ok, name, detail=""):
+    print(f"{'PASS' if ok else 'FAIL'} {name}"
+          f"{(' — ' + detail) if detail else ''}")
+    if not ok:
+        _failures.append(name)
+
+
+def _rows(a):
+    return {tuple(map(int, row)) for row in np.asarray(a)}
+
+
+def gate_W1():
+    bad = []
+    for toy in T.all_toys():
+        exact = enumerate_worlds(toy.root)
+        sampler = WorldSampler.from_root(toy.root)
+        if sampler.n_worlds != len(exact):
+            bad.append(f"{toy.name}:{sampler.n_worlds}!={len(exact)}")
+    _gate(not bad, "W1 DP count equals exact enumeration on all toys",
+          "; ".join(bad) if bad else "8 roots")
+
+
+def gate_W2():
+    root = T.get_toy("t2_decl_w12").root
+    exact = _rows(enumerate_worlds(root))
+    sampler = WorldSampler.from_root(root)
+    host = sampler.sample(4000, seed=123)
+    metal = sampler.sample_metal(4000, seed=456)
+    valid = all(row in exact for row in _rows(host)) \
+        and all(row in exact for row in _rows(metal))
+    complete = _rows(host) == exact and _rows(metal) == exact
+    _gate(valid and complete, "W2 host and Metal samples are physical",
+          f"population {len(exact)}, host/metal support complete")
+
+
+def gate_W3():
+    root = T.get_toy("t2_decl_w12").root
+    sampler = WorldSampler.from_root(root)
+    exact = sorted(_rows(enumerate_worlds(root)))
+    draw = sampler.sample_metal(24000, seed=789)
+    idx = {w: i for i, w in enumerate(exact)}
+    count = np.zeros(len(exact), dtype=int)
+    for row in draw:
+        count[idx[tuple(map(int, row))]] += 1
+    expected = len(draw) / len(exact)
+    max_rel = float(np.max(np.abs(count - expected)) / expected)
+    _gate(max_rel < 0.15, "W3 Metal sampler empirical uniformity",
+          f"max relative cell deviation {max_rel:.3f}")
+
+
+def gate_W4():
+    common = dict(decl_id=7, bidder=3, bid_value=38,
+                  bids=(0, 0, 0, 38), dealer=0, current_trick=())
+    h5 = EndgameRoot(
+        **common, me=3, my_hand=(1, 11, 13, 19, 25),
+        play_history=((3, 26), (0, 24), (1, 14), (2, 23),
+                      (1, 3), (2, 12), (3, 5), (0, 4)),
+        trick_leader=3, team_points=(0, 2))
+    h6 = EndgameRoot(
+        **common, me=1, my_hand=(2, 3, 7, 8, 15, 17),
+        play_history=((3, 26), (0, 24), (1, 14), (2, 23)),
+        trick_leader=1, team_points=(0, 1))
+    got = (WorldSampler.from_root(h5).n_worlds,
+           WorldSampler.from_root(h6).n_worlds)
+    _gate(got == (324_324, 17_153_136),
+          "W4 registered H5/H6 populations fit the DP",
+          f"{got[0]:,} / {got[1]:,} worlds")
+
+
+def main():
+    gate_W1()
+    gate_W2()
+    gate_W3()
+    gate_W4()
+    if _failures:
+        print(f"\n{len(_failures)} gate(s) FAILED: {_failures}")
+        return 1
+    print("\nall world-sampler gates green")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/hoyt/worldsample.py
+++ b/hoyt/worldsample.py
@@ -1,0 +1,190 @@
+"""Exact bounded-memory sampling of physical hidden worlds.
+
+``walt.worlds.enumerate_worlds`` is the audit oracle.  This module represents
+the same conservation and public void constraints with a tiny continuation-
+count dynamic program, then samples assignments without materializing the
+world population.  The table is at most ``22 * 8^3`` uint32 values, including
+an H7 root.
+
+``sample_metal`` executes one independent sampler per Metal thread.  Its
+counter-based random stream is keyed by ``(seed, sample, tile, retry)`` and
+uses rejection before modulo, so every legal continuation is selected with
+the same pseudorandom probability.  No rejection over whole deals is used.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+from walt.tables import N_DOMINOES
+from walt.worlds import _void_forbidden, seat_order
+
+__all__ = ["WorldSampler"]
+
+_DP_SHAPE = (22, 8, 8, 8)
+
+
+_SAMPLE_SOURCE = r"""
+    uint i = thread_position_in_grid.x;
+
+    uint cap[3] = {counts[0], counts[1], counts[2]};
+    uint hand[3] = {0u, 0u, 0u};
+    ulong base_seed = seed[0] ^ ((ulong)i * 0x9E3779B97F4A7C15ul);
+
+    for (uint k = 0; k < ntiles[0]; ++k) {
+        uint weight[3] = {0u, 0u, 0u};
+        uint total = 0u;
+        uint am = allowed[k];
+        for (uint s = 0; s < 3; ++s) {
+            if ((am & (1u << s)) && cap[s] > 0u) {
+                uint c0 = cap[0] - (s == 0u);
+                uint c1 = cap[1] - (s == 1u);
+                uint c2 = cap[2] - (s == 2u);
+                uint at = (k + 1u) * 512u + c0 * 64u + c1 * 8u + c2;
+                weight[s] = dp[at];
+                total += weight[s];
+            }
+        }
+
+        ulong x = base_seed ^ ((ulong)k * 0xD1B54A32D192ED03ul);
+        ulong threshold = (0ul - (ulong)total) % (ulong)total;
+        ulong z;
+        uint retry = 0u;
+        do {
+            x += 0x9E3779B97F4A7C15ul + (ulong)retry++;
+            z = x;
+            z = (z ^ (z >> 30)) * 0xBF58476D1CE4E5B9ul;
+            z = (z ^ (z >> 27)) * 0x94D049BB133111EBul;
+            z ^= z >> 31;
+        } while (z < threshold);
+        uint draw = (uint)(z % (ulong)total);
+
+        uint owner = 0u;
+        while (draw >= weight[owner]) {
+            draw -= weight[owner];
+            owner += 1u;
+        }
+        cap[owner] -= 1u;
+        hand[owner] |= 1u << tiles[k];
+    }
+    worlds[i * 3u] = hand[0];
+    worlds[i * 3u + 1u] = hand[1];
+    worlds[i * 3u + 2u] = hand[2];
+"""
+
+
+@dataclass
+class WorldSampler:
+    seats: tuple[int, int, int]
+    tiles: np.ndarray
+    allowed: np.ndarray
+    counts: np.ndarray
+    dp: np.ndarray
+
+    @classmethod
+    def from_root(cls, root):
+        seats = seat_order(root)
+        played = {int(d) for _, d in root.play_history}
+        mine = {int(t) for t in root.my_hand}
+        tiles = np.asarray(sorted(set(range(N_DOMINOES)) - played - mine),
+                           dtype=np.uint8)
+        made = {s: 0 for s in seats}
+        for seat, _ in root.play_history:
+            if seat in made:
+                made[seat] += 1
+        counts = np.asarray([7 - made[s] for s in seats], dtype=np.uint8)
+        if int(counts.sum()) != len(tiles):
+            raise ValueError("root violates hidden-tile conservation")
+
+        forbidden = _void_forbidden(root)
+        allowed = np.zeros(len(tiles), dtype=np.uint8)
+        for k, tile in enumerate(tiles):
+            bit = np.uint32(1) << np.uint32(tile)
+            for col, seat in enumerate(seats):
+                if not (forbidden[seat] & bit):
+                    allowed[k] |= np.uint8(1 << col)
+            if allowed[k] == 0:
+                raise ValueError(f"tile {int(tile)} has no legal hidden owner")
+
+        dp = np.zeros(_DP_SHAPE, dtype=np.uint32)
+        dp[len(tiles), 0, 0, 0] = 1
+        for k in range(len(tiles) - 1, -1, -1):
+            am = int(allowed[k])
+            remaining = len(tiles) - k
+            for c0 in range(min(7, remaining) + 1):
+                for c1 in range(min(7, remaining - c0) + 1):
+                    c2 = remaining - c0 - c1
+                    if not 0 <= c2 <= 7:
+                        continue
+                    total = 0
+                    if am & 1 and c0:
+                        total += int(dp[k + 1, c0 - 1, c1, c2])
+                    if am & 2 and c1:
+                        total += int(dp[k + 1, c0, c1 - 1, c2])
+                    if am & 4 and c2:
+                        total += int(dp[k + 1, c0, c1, c2 - 1])
+                    dp[k, c0, c1, c2] = np.uint32(total)
+        out = cls(seats=seats, tiles=tiles, allowed=allowed,
+                  counts=counts, dp=dp)
+        if out.n_worlds == 0:
+            raise ValueError("root has no physical hidden worlds")
+        return out
+
+    @property
+    def n_worlds(self) -> int:
+        c0, c1, c2 = map(int, self.counts)
+        return int(self.dp[0, c0, c1, c2])
+
+    def sample(self, n: int, seed: int = 0) -> np.ndarray:
+        """Sample ``n`` uniform legal worlds on the host, without enumeration."""
+        if n < 0:
+            raise ValueError("n must be nonnegative")
+        rng = np.random.default_rng(seed)
+        out = np.zeros((n, 3), dtype=np.uint32)
+        for i in range(n):
+            cap = self.counts.astype(np.int16)
+            for k, tile in enumerate(self.tiles):
+                weights = np.zeros(3, dtype=np.uint32)
+                for s in range(3):
+                    if int(self.allowed[k]) & (1 << s) and cap[s] > 0:
+                        nxt = cap.copy()
+                        nxt[s] -= 1
+                        weights[s] = self.dp[k + 1, *map(int, nxt)]
+                total = int(weights.sum())
+                draw = int(rng.integers(total))
+                owner = 0
+                while draw >= int(weights[owner]):
+                    draw -= int(weights[owner])
+                    owner += 1
+                cap[owner] -= 1
+                out[i, owner] |= np.uint32(1) << np.uint32(tile)
+        return out
+
+    def sample_metal(self, n: int, seed: int = 0) -> np.ndarray:
+        """Sample ``n`` uniform legal worlds with one Metal thread per deal."""
+        if n < 0:
+            raise ValueError("n must be nonnegative")
+        if n == 0:
+            return np.zeros((0, 3), dtype=np.uint32)
+        try:
+            import mlx.core as mx
+        except ImportError as exc:
+            raise RuntimeError("sample_metal requires MLX") from exc
+        if "gpu" not in str(mx.default_device()).lower():
+            raise RuntimeError("sample_metal requires the MLX Metal GPU")
+        kernel = mx.fast.metal_kernel(
+            name="hoyt_world_sample",
+            input_names=["tiles", "allowed", "counts", "dp", "ntiles",
+                         "seed"],
+            output_names=["worlds"], source=_SAMPLE_SOURCE)
+        worlds, = kernel(
+            inputs=[mx.array(self.tiles.astype(np.uint32)),
+                    mx.array(self.allowed.astype(np.uint32)),
+                    mx.array(self.counts.astype(np.uint32)),
+                    mx.array(self.dp.reshape(-1)),
+                    mx.array([len(self.tiles)], dtype=mx.uint32),
+                    mx.array([seed & ((1 << 64) - 1)], dtype=mx.uint64)],
+            grid=(n, 1, 1), threadgroup=(min(256, n), 1, 1),
+            output_shapes=[(n * 3,)], output_dtypes=[mx.uint32])
+        return np.asarray(worlds, dtype=np.uint32).reshape(n, 3)

--- a/wiki/entities/hoyt.md
+++ b/wiki/entities/hoyt.md
@@ -85,11 +85,11 @@ info set in about the cost of one ordinary solve — after which:
 
 Habitat: **H ≤ 4 comfortable** (H3 nearly free); H5 needs a measured
 population baseline plus a new execution lane; H6+ is a different build.
-[[full-metal-hoyt]] states the active structural question: can a
-device-resident, root-batched Metal lane carry build + iteration + gap
-certification far enough to make H5/H6 reference lines practical without
-weakening the referee? Per tile of horizon: BR pays ~1 order of magnitude
-uncapped and ~nothing capped; CFR pays ~1.5 orders in both time and memory.
+[[full-metal-hoyt]] states the active structural question: build a fast,
+device-resident, root-batched Metal lane that makes H5 and H6 reference lines
+practical with calibrated error bars. Bit replication is not part of that
+goal. Per tile of horizon: BR pays ~1 order of magnitude uncapped and ~nothing
+capped; CFR pays ~1.5 orders in both time and memory.
 
 ## The honesty line (registered before building)
 

--- a/wiki/entities/hoyt.md
+++ b/wiki/entities/hoyt.md
@@ -2,7 +2,7 @@
 title: hoyt — the game's own referee
 kind: entity
 first_seen: 2026-07-18
-last_updated: 2026-07-19
+last_updated: 2026-07-21
 status: active
 ---
 
@@ -83,11 +83,13 @@ info set in about the cost of one ordinary solve — after which:
 | mixing | ~500 toy configurations, zero mixed equilibria — vs deterministic fields, late 42 is **pure**; mixing must earn via concealment, not value |
 | exact equivalence ([[endgame-equivalence-census]]) | world/root compression exactly 1.000× (co-occurrence theorem — dead at every horizon); within-hand interchangeable pairs in 25/200 roots, 29/29 bitwise value-tie receipts via `hoyt/equivcensus.py` |
 
-Habitat: **H ≤ 4 comfortable** (H3 nearly free); H5 needs the queued
-int32 narrowing + small caps; H6+ is a different build (streaming /
-Metal / sampling — parked). Per tile of horizon: BR pays ~1 order of
-magnitude uncapped and ~nothing capped; CFR pays ~1.5 orders in both
-time and memory.
+Habitat: **H ≤ 4 comfortable** (H3 nearly free); H5 needs a measured
+population baseline plus a new execution lane; H6+ is a different build.
+[[full-metal-hoyt]] states the active structural question: can a
+device-resident, root-batched Metal lane carry build + iteration + gap
+certification far enough to make H5/H6 reference lines practical without
+weakening the referee? Per tile of horizon: BR pays ~1 order of magnitude
+uncapped and ~nothing capped; CFR pays ~1.5 orders in both time and memory.
 
 ## The honesty line (registered before building)
 
@@ -112,4 +114,4 @@ per-root form of [#72](https://github.com/jasonyandell/mk5-main/issues/72)).
 
 [[walt]] · [[walt-spec]] · [[perf]] · [[perf-log]] · [[jud]] ·
 [[belief-policy-value-algebra]] · [[count-fate-ledger]] · [[the-wall]] ·
-[[cfr-primer]] · [[endgame-equivalence-census]]
+[[cfr-primer]] · [[endgame-equivalence-census]] · [[full-metal-hoyt]]

--- a/wiki/entities/hoyt.md
+++ b/wiki/entities/hoyt.md
@@ -2,7 +2,7 @@
 title: hoyt — the game's own referee
 kind: entity
 first_seen: 2026-07-18
-last_updated: 2026-07-21
+last_updated: 2026-07-22
 status: active
 ---
 
@@ -83,6 +83,7 @@ info set in about the cost of one ordinary solve — after which:
 | mixing | ~500 toy configurations, zero mixed equilibria — vs deterministic fields, late 42 is **pure**; mixing must earn via concealment, not value |
 | exact equivalence ([[endgame-equivalence-census]]) | world/root compression exactly 1.000× (co-occurrence theorem — dead at every horizon); within-hand interchangeable pairs in 25/200 roots, 29/29 bitwise value-tie receipts via `hoyt/equivcensus.py` |
 | full-metal first slice (2026-07-21) | dense H4 anchor 10.31→3.77 s; dense H5/eight-world/ten-round 25.4→19.4 s; dense H6 refuted at one world (>288M slots). Shared sampled CFR covers the full H5/H6 world populations in bounded memory: H5 13.39 s train + 13.02 s four-seat audit; H6 5.37 s + 11.81 s, 305,277 rows / 27,219 peak frontier. Both remain unresolved until BR shortfall is calibrated ([[full-metal-hoyt]]) |
+| playable late-hand smoke (2026-07-22) | `hoyt/play.py` seats a human at H5/H6 and independently re-solves the other seats from their own information. Seed 910000 all-Hoyt continuation: H5 20 plays / 8 non-forced solves / 14.57 s solve wall; H6 24 / 11 / 17.01 s. Make/set utility; physical-uniform belief; single smokes, not strength or calibration claims ([[full-metal-hoyt]]) |
 
 Habitat: **H ≤ 4 comfortable** (H3 nearly free); H5 needs a measured
 population baseline plus a new execution lane; H6+ is a different build.
@@ -109,7 +110,9 @@ Exploitability pricing for [#77](https://github.com/jasonyandell/mk5-main/issues
 fact says concealment is mixing's only paycheck); the stable eval for
 every future player generation; reference values for the
 [[count-fate-ledger]] referees; rent-decomposition of walt's edge (the
-per-root form of [#72](https://github.com/jasonyandell/mk5-main/issues/72)).
+per-root form of [#72](https://github.com/jasonyandell/mk5-main/issues/72));
+and an explicitly experimental H5/H6 human table that tests whether the
+bounded candidate behaves coherently before calibration is complete.
 
 ## Links
 

--- a/wiki/entities/hoyt.md
+++ b/wiki/entities/hoyt.md
@@ -82,14 +82,15 @@ info set in about the cost of one ordinary solve — after which:
 | refsweep cascade velocity | rung-0 **224 evals/hour** pre-kernel; post 18l–19a (threads=4 default): same-seed paired sample **23.7× less worker-time per usable eval** (11.7 worker-s), 19/20 converge at rung 0 and the 555090 wedge now cashes at rung 2 (473 s full-cascade root-wall; banked: 1,799 s) → **~3,400–4,650/hour projected** ([[perf-log]] 19a); deepening 87% → 99% → 100% over three rungs pre-kernel |
 | mixing | ~500 toy configurations, zero mixed equilibria — vs deterministic fields, late 42 is **pure**; mixing must earn via concealment, not value |
 | exact equivalence ([[endgame-equivalence-census]]) | world/root compression exactly 1.000× (co-occurrence theorem — dead at every horizon); within-hand interchangeable pairs in 25/200 roots, 29/29 bitwise value-tie receipts via `hoyt/equivcensus.py` |
+| full-metal first slice (2026-07-21) | dense H4 anchor 10.31→3.77 s; dense H5/eight-world/ten-round 25.4→19.4 s; dense H6 refuted at one world (>288M slots). Shared sampled CFR covers the full H5/H6 world populations in bounded memory: H5 13.39 s train + 13.02 s four-seat audit; H6 5.37 s + 11.81 s, 305,277 rows / 27,219 peak frontier. Both remain unresolved until BR shortfall is calibrated ([[full-metal-hoyt]]) |
 
 Habitat: **H ≤ 4 comfortable** (H3 nearly free); H5 needs a measured
 population baseline plus a new execution lane; H6+ is a different build.
-[[full-metal-hoyt]] states the active structural question: build a fast,
-device-resident, root-batched Metal lane that makes H5 and H6 reference lines
-practical with calibrated error bars. Bit replication is not part of that
-goal. Per tile of horizon: BR pays ~1 order of magnitude uncapped and ~nothing
-capped; CFR pays ~1.5 orders in both time and memory.
+[[full-metal-hoyt]] now splits the lane: dense Metal is a measured H4/H5
+accelerator, while H6 requires sparse external sampling plus a calibrated
+sampled-BR shortfall bound. Bit replication is not part of the goal. Per tile
+of horizon: dense BR pays ~1 order of magnitude uncapped and ~nothing capped;
+dense CFR pays ~1.5 orders in both time and memory.
 
 ## The honesty line (registered before building)
 

--- a/wiki/index-topics.md
+++ b/wiki/index-topics.md
@@ -41,7 +41,7 @@ Concepts, methods, and synthesized findings.
 - [[topics/eq-gate-star|eq-gate-star]] — staged iter-2/3 workstream: gate STaR keep on E[Q] delta, not just K1 match (retired)
 - [[topics/eval-matrix-bradley-terry|eval-matrix-bradley-terry]] — Bradley-Terry Elo tournament infra over named players (zeb checkpoints, random, heuristic, eq:n=10/50/100/500) (complete)
 - [[topics/expected-q-value|expected-q-value]] — E[Q]: scalar measuring position value, supplied by forge's Q-value checkpoint (active)
-- [[topics/full-metal-hoyt|full-metal-hoyt]] — problem statement for a device-resident, root-batched Metal Hoyt lane that makes H5/H6 reference production practical without weakening fp64-certified gap semantics (active)
+- [[topics/full-metal-hoyt|full-metal-hoyt]] — build a fast, device-resident, root-batched Metal Hoyt that makes H5 and H6 reference solving practical with confident calibrated error bars; bit replication is a non-goal (active)
 - [[topics/game-context-qa|game-context-qa]] — 5-type game-context Q&A from real game records, ~170 tok prompts; expanded to 14 categories in v9 (superseded)
 - [[topics/hoyt-perf-primer|hoyt-perf-primer]] — plain-language decoder for the hoyt perf campaign: H4/anchor/worlds/cap/gap/rent/banked/rungs/wedge/pull-queue defined in birth order, runtime characteristics milestone by milestone (18.5 → 727 evals/hr), and the structural fork (active)
 - [[topics/huggingface-assets|huggingface-assets]] — account-verified catalog of every HF repo the project generated (4 datasets incl. mk5-run-evidence, ~95 model repos, plus referenced-but-absent names); the off-git shelf run-artifacts-policy points at (active)

--- a/wiki/index-topics.md
+++ b/wiki/index-topics.md
@@ -41,7 +41,7 @@ Concepts, methods, and synthesized findings.
 - [[topics/eq-gate-star|eq-gate-star]] — staged iter-2/3 workstream: gate STaR keep on E[Q] delta, not just K1 match (retired)
 - [[topics/eval-matrix-bradley-terry|eval-matrix-bradley-terry]] — Bradley-Terry Elo tournament infra over named players (zeb checkpoints, random, heuristic, eq:n=10/50/100/500) (complete)
 - [[topics/expected-q-value|expected-q-value]] — E[Q]: scalar measuring position value, supplied by forge's Q-value checkpoint (active)
-- [[topics/full-metal-hoyt|full-metal-hoyt]] — build a fast, device-resident, root-batched Metal Hoyt that makes H5 and H6 reference solving practical with confident calibrated error bars; bit replication is a non-goal (active)
+- [[topics/full-metal-hoyt|full-metal-hoyt]] — bounded sparse Metal H5/H6 now runs and has a resumable human table; reference gaps remain unresolved until optimization-shortfall calibration, while bit replication remains a non-goal (active)
 - [[topics/game-context-qa|game-context-qa]] — 5-type game-context Q&A from real game records, ~170 tok prompts; expanded to 14 categories in v9 (superseded)
 - [[topics/hoyt-perf-primer|hoyt-perf-primer]] — plain-language decoder for the hoyt perf campaign: H4/anchor/worlds/cap/gap/rent/banked/rungs/wedge/pull-queue defined in birth order, runtime characteristics milestone by milestone (18.5 → 727 evals/hr), and the structural fork (active)
 - [[topics/huggingface-assets|huggingface-assets]] — account-verified catalog of every HF repo the project generated (4 datasets incl. mk5-run-evidence, ~95 model repos, plus referenced-but-absent names); the off-git shelf run-artifacts-policy points at (active)

--- a/wiki/index-topics.md
+++ b/wiki/index-topics.md
@@ -41,6 +41,7 @@ Concepts, methods, and synthesized findings.
 - [[topics/eq-gate-star|eq-gate-star]] — staged iter-2/3 workstream: gate STaR keep on E[Q] delta, not just K1 match (retired)
 - [[topics/eval-matrix-bradley-terry|eval-matrix-bradley-terry]] — Bradley-Terry Elo tournament infra over named players (zeb checkpoints, random, heuristic, eq:n=10/50/100/500) (complete)
 - [[topics/expected-q-value|expected-q-value]] — E[Q]: scalar measuring position value, supplied by forge's Q-value checkpoint (active)
+- [[topics/full-metal-hoyt|full-metal-hoyt]] — problem statement for a device-resident, root-batched Metal Hoyt lane that makes H5/H6 reference production practical without weakening fp64-certified gap semantics (active)
 - [[topics/game-context-qa|game-context-qa]] — 5-type game-context Q&A from real game records, ~170 tok prompts; expanded to 14 categories in v9 (superseded)
 - [[topics/hoyt-perf-primer|hoyt-perf-primer]] — plain-language decoder for the hoyt perf campaign: H4/anchor/worlds/cap/gap/rent/banked/rungs/wedge/pull-queue defined in birth order, runtime characteristics milestone by milestone (18.5 → 727 evals/hr), and the structural fork (active)
 - [[topics/huggingface-assets|huggingface-assets]] — account-verified catalog of every HF repo the project generated (4 datasets incl. mk5-run-evidence, ~95 model repos, plus referenced-but-absent names); the off-git shelf run-artifacts-policy points at (active)

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -26,9 +26,9 @@ What the log recorded, phase by phase. The story itself lives in the hubs and tr
 ## [2026-07-21 | conversation | full-metal Hoyt problem statement]
 
 **Touched pages:** [[full-metal-hoyt]] [[hoyt]] [[perf]] `questions/open.md` [[index-topics|index]]
-**Added:** [[full-metal-hoyt]] — the post-#84 structural question: move Hoyt's ragged root fleet, full-width build, CFR+ sweeps, and certificate path into a device-resident Metal lane whose purpose is a practical H5 then H6 reference line.
-**Gates:** exact structural parity; an explicit answer to Metal's missing fp64 after the CPU fp32 license failed; frozen H4 replay with authoritative gap repricing; full-population H5 horizon proof; consumable reference artifact.
-**Kept:** Hoyt's exact-given-worlds single-seat-BR gap claim and team-game honesty line; no H4-only kernel win counts as completion.
+**Added:** [[full-metal-hoyt]] — move Hoyt's ragged root fleet, full-width build, CFR+ sweeps, and reference evaluation into a fast device-resident Metal lane; H4 is calibration, practical H5 and H6 lines are the goals.
+**Gates:** held-out error-bar coverage for value, gap, convergence, and action damage; H5 throughput; H6 throughput; consumable reference artifacts.
+**Non-goals:** bit replication, identical reductions, per-root CPU certification, and any H4-only win.
 
 ## [2026-07-17 | worktree-walt | walt: exact endgame info-set solver — built, graded, integrated]
 

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -23,6 +23,13 @@ What the log recorded, phase by phase. The story itself lives in the hubs and tr
 
 ---
 
+## [2026-07-21 | conversation | full-metal Hoyt problem statement]
+
+**Touched pages:** [[full-metal-hoyt]] [[hoyt]] [[perf]] `questions/open.md` [[index-topics|index]]
+**Added:** [[full-metal-hoyt]] — the post-#84 structural question: move Hoyt's ragged root fleet, full-width build, CFR+ sweeps, and certificate path into a device-resident Metal lane whose purpose is a practical H5 then H6 reference line.
+**Gates:** exact structural parity; an explicit answer to Metal's missing fp64 after the CPU fp32 license failed; frozen H4 replay with authoritative gap repricing; full-population H5 horizon proof; consumable reference artifact.
+**Kept:** Hoyt's exact-given-worlds single-seat-BR gap claim and team-game honesty line; no H4-only kernel win counts as completion.
+
 ## [2026-07-17 | worktree-walt | walt: exact endgame info-set solver — built, graded, integrated]
 
 **Touched pages:** [[walt]] [[walt-spec]] [[the-wall-biography]] [[jud]] [[champion-ladder]] [[the-wall]] [[the-gestation]] [[index-entities|index]] [[index-topics|index]]

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -30,6 +30,13 @@ What the log recorded, phase by phase. The story itself lives in the hubs and tr
 **Gates:** held-out error-bar coverage for value, gap, convergence, and action damage; H5 throughput; H6 throughput; consumable reference artifacts.
 **Non-goals:** bit replication, identical reductions, per-root CPU certification, and any H4-only win.
 
+## [2026-07-21 | working | full-metal iterate survives; dense H6 refuted]
+
+**Touched pages:** [[full-metal-hoyt]] [[perf-log]] `questions/open.md`
+**Landed:** custom-Metal float32 CFR+ iterate/gap passes, exact DP Metal world sampling, shared four-seat sparse sampled CFR, frozen-policy BR forks, candidate-policy artifacts, and conformal value/gap/BR-shortfall calibration primitives.
+**Refuted:** dense H6 exceeded 288,991,264 live slots at one world before iteration; the surviving design is a bounded-memory sampled/streamed estimator with calibrated errors.
+**Measured:** full-population H5 shared CFR + four-seat candidate audit took 13.39 + 13.02 s; H6 took 5.37 + 11.81 s with 305,277 information rows and 27,219 peak frontier states. Candidate statistical bands are finite, but true upper gaps remain infinite until optimization shortfall is calibrated; both verdicts are `unresolved`.
+
 ## [2026-07-17 | worktree-walt | walt: exact endgame info-set solver — built, graded, integrated]
 
 **Touched pages:** [[walt]] [[walt-spec]] [[the-wall-biography]] [[jud]] [[champion-ladder]] [[the-wall]] [[the-gestation]] [[index-entities|index]] [[index-topics|index]]

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -23,6 +23,13 @@ What the log recorded, phase by phase. The story itself lives in the hubs and tr
 
 ---
 
+## [2026-07-22 | working | full-metal Hoyt sits at the table]
+
+**Touched pages:** [[full-metal-hoyt]] [[hoyt]] `hoyt/CONTRACTS.md` `questions/open.md`
+**Landed:** `hoyt/play.py` — a resumable human H5/H6 continuation whose bot roots and random streams see only the acting hand plus public state; make/set utility by default; fixed-candidate action bands remain explicitly shortfall-uncalibrated.
+**Smoked:** seed 910000 all-Hoyt continuation: H5 20 remaining plays / 8 Metal re-solves / 14.57 s solve wall; H6 24 / 11 / 17.01 s. These are single playability receipts, not strength or fleet benchmarks.
+**Gate:** perturbing the referee's hidden holdings cannot change the solver root; hidden hands do not render; sessions round-trip; forced moves bypass solving; complete continuations remain zeb-legal.
+
 ## [2026-07-21 | conversation | full-metal Hoyt problem statement]
 
 **Touched pages:** [[full-metal-hoyt]] [[hoyt]] [[perf]] `questions/open.md` [[index-topics|index]]

--- a/wiki/questions/open.md
+++ b/wiki/questions/open.md
@@ -12,6 +12,10 @@ Format:
 
 ---
 
+- **Q:** Can a device-resident, root-batched [[full-metal-hoyt]] lane make H5 and then H6 reference production practical on the M5 Max while preserving Hoyt's fp64-certified single-seat-BR gap contract despite Metal's lack of `double`?
+  - Raised: conversation 2026-07-21 ([[full-metal-hoyt]])
+  - Context: The #78→#81→#83→#84 stack exhausted H4 CPU micro-performance and exact structural compression: 727 certified H4 evals/hour, world/root equivalence 1.000×, own-equals class-CFR only ~3% of non-forced slots. The open mechanism is fleet-level GPU residency across build + CFR + certificate, not another isolated kernel.
+
 - **Q:** Does switching forge's production `select_actions` from Lens(p_make) to ev-argmax raise the Zeb-Large win rate above the current 55.7% (E[Q] N=100)?
   - Raised: `afd4802` ([[w42-lens-v1-utility-head-to-head]])
   - Context: `forge/eq/generate/actions.py::select_actions` hardcodes p_make-argmax-with-EV-tiebreak — effectively Lens(p_make), the **worst** of the four utilities in the Lens v1 round-robin (Lens(ev) beats Lens(p_make) by +5.42 pts/hand). The recommended one-line switch to ev-argmax is **NOT applied** as of `afd4802` (verified against the current file plus the Zeb-protocol play path in `forge/zeb/eq_player.py`) — open two months on.

--- a/wiki/questions/open.md
+++ b/wiki/questions/open.md
@@ -15,6 +15,8 @@ Format:
 - **Q:** Can a fast, device-resident, root-batched [[full-metal-hoyt]] lane make H5 and H6 reference production practical on the M5 Max with error bars calibrated tightly enough to support reference values, gaps, and action choices?
   - Raised: conversation 2026-07-21 ([[full-metal-hoyt]])
   - Context: The #78→#81→#83→#84 stack exhausted H4 CPU micro-performance and exact structural compression: 727 H4 evals/hour, world/root equivalence 1.000×, own-equals class-CFR only ~3% of non-forced slots. H4 is the calibration set; fast H5 and H6 are the goals. Bit replication and per-root CPU certification are non-goals.
+  - *Narrowed 2026-07-21:* Dense full-width H6 is refuted even at one world: the walk exceeded 288,991,264 live slots before iteration. The open mechanism is a bounded-memory sampled/streamed Metal estimator with held-out value, gap, convergence, and action error bars.
+  - *Advanced 2026-07-21:* Exact DP world sampling, shared four-seat sparse CFR, frozen-policy BR forks, and policy artifacts now run on full H5/H6 populations in seconds. The remaining correctness hinge is a transferable one-sided BR-optimization-shortfall bound; without it the H5/H6 convergence verdicts correctly remain unresolved.
 
 - **Q:** Does switching forge's production `select_actions` from Lens(p_make) to ev-argmax raise the Zeb-Large win rate above the current 55.7% (E[Q] N=100)?
   - Raised: `afd4802` ([[w42-lens-v1-utility-head-to-head]])

--- a/wiki/questions/open.md
+++ b/wiki/questions/open.md
@@ -12,9 +12,9 @@ Format:
 
 ---
 
-- **Q:** Can a device-resident, root-batched [[full-metal-hoyt]] lane make H5 and then H6 reference production practical on the M5 Max while preserving Hoyt's fp64-certified single-seat-BR gap contract despite Metal's lack of `double`?
+- **Q:** Can a fast, device-resident, root-batched [[full-metal-hoyt]] lane make H5 and H6 reference production practical on the M5 Max with error bars calibrated tightly enough to support reference values, gaps, and action choices?
   - Raised: conversation 2026-07-21 ([[full-metal-hoyt]])
-  - Context: The #78→#81→#83→#84 stack exhausted H4 CPU micro-performance and exact structural compression: 727 certified H4 evals/hour, world/root equivalence 1.000×, own-equals class-CFR only ~3% of non-forced slots. The open mechanism is fleet-level GPU residency across build + CFR + certificate, not another isolated kernel.
+  - Context: The #78→#81→#83→#84 stack exhausted H4 CPU micro-performance and exact structural compression: 727 H4 evals/hour, world/root equivalence 1.000×, own-equals class-CFR only ~3% of non-forced slots. H4 is the calibration set; fast H5 and H6 are the goals. Bit replication and per-root CPU certification are non-goals.
 
 - **Q:** Does switching forge's production `select_actions` from Lens(p_make) to ev-argmax raise the Zeb-Large win rate above the current 55.7% (E[Q] N=100)?
   - Raised: `afd4802` ([[w42-lens-v1-utility-head-to-head]])

--- a/wiki/questions/open.md
+++ b/wiki/questions/open.md
@@ -17,6 +17,7 @@ Format:
   - Context: The #78→#81→#83→#84 stack exhausted H4 CPU micro-performance and exact structural compression: 727 H4 evals/hour, world/root equivalence 1.000×, own-equals class-CFR only ~3% of non-forced slots. H4 is the calibration set; fast H5 and H6 are the goals. Bit replication and per-root CPU certification are non-goals.
   - *Narrowed 2026-07-21:* Dense full-width H6 is refuted even at one world: the walk exceeded 288,991,264 live slots before iteration. The open mechanism is a bounded-memory sampled/streamed Metal estimator with held-out value, gap, convergence, and action error bars.
   - *Advanced 2026-07-21:* Exact DP world sampling, shared four-seat sparse CFR, frozen-policy BR forks, and policy artifacts now run on full H5/H6 populations in seconds. The remaining correctness hinge is a transferable one-sided BR-optimization-shortfall bound; without it the H5/H6 convergence verdicts correctly remain unresolved.
+  - *Playable 2026-07-22:* A resumable human-vs-Hoyt H5/H6 table now projects every bot decision through the acting seat's information boundary. Single seed-910000 continuations cost 14.57 s (H5) and 17.01 s (H6) of total solve wall because many late plays are forced. This establishes playability only; strength, behavior-conditioned beliefs, and the calibration hinge remain open.
 
 - **Q:** Does switching forge's production `select_actions` from Lens(p_make) to ev-argmax raise the Zeb-Large win rate above the current 55.7% (E[Q] N=100)?
   - Raised: `afd4802` ([[w42-lens-v1-utility-head-to-head]])

--- a/wiki/topics/full-metal-hoyt.md
+++ b/wiki/topics/full-metal-hoyt.md
@@ -23,7 +23,7 @@ stack exhausted the credible CPU and exact-compression levers:
   slots.
 
 The remaining opportunity is the unused parallelism across the solve itself:
-move Hoyt's full-width tree construction, CFR sweeps, and reference evaluation
+move Hoyt's structural sampling/build, CFR sweeps, and reference evaluation
 onto the GPU, keep the work device-resident, and batch the ragged population of
 roots rather than running a few memory-contending CPU processes.
 
@@ -53,7 +53,7 @@ in the production H5/H6 path.
 
 The production path keeps the expensive work on the GPU:
 
-- full-width wave/tree construction;
+- sampled or streamed wave/tree construction;
 - information-set and strategy layout;
 - CFR forward and backward passes;
 - regret and average-policy updates;
@@ -76,6 +76,90 @@ The work succeeds when it produces:
 It fails if the error bars are too wide to support decisions, if host/device
 synchronization dominates, if ragged roots leave the GPU mostly idle, or if the
 result is merely a faster H4 solver.
+
+## Finding: a dense port cannot be H6
+
+The first implementation established a real custom-Metal CFR+ vertical slice
+over Hoyt's forced-slot-compressed segment layout. On the quiet M5 Max:
+
+- H4 anchor 555006: Metal iterate 0.225 s versus 3.506 s for four-thread
+  fused CPU (15.6x); device-side gap pricing reduced the complete solve to
+  3.77 s versus 10.31 s (2.74x). Float32 drift after 40 rounds was 0.0336
+  points in value and 0.00129 in measured gap.
+- H5 seed 910000 at eight worlds: Metal iterate 0.265 s versus 3.150 s
+  (11.9x) for ten rounds; the complete solve was 19.4 s versus 25.4 s
+  (1.31x). Host construction and export now dominate. Float32 drift was
+  0.00539 points in value and 0.00216 in gap.
+- H6 seed 910000 at **one world**: the dense walk exceeded 288,991,264 live
+  slots at play 21 and hit the 256M slot cap before any CFR iteration. The
+  root has 17,153,136 possible hidden worlds.
+
+This refutes “put the existing full-width tree on Metal” as the H6
+architecture. The iterate kernels are viable and worth keeping, but full Metal
+must change the structural estimator: sampled trajectories, streamed/chunked
+waves, or another bounded representation whose value/gap/action errors can be
+calibrated on H4 and small-support H5. The uncertainty license applies to the
+structure as well as float arithmetic; otherwise H6 cannot fit.
+
+The next decision is therefore algorithmic, not another kernel micro-pass:
+choose an estimator that (1) has bounded device memory independent of the full
+tree, (2) exposes statistically honest value and gap intervals, (3) supports
+root-fleet batching, and (4) survives held-out CPU calibration.
+
+## Surviving implementation: sparse external sampling
+
+The bounded-memory route now has a working first slice:
+
+- `hoyt/worldsample.py` replaces world enumeration with a tiny exact
+  continuation-count DP and samples one legal deal per Metal thread. Counts
+  match exhaustive enumeration on every toy; a 24,000-draw Metal gate is
+  uniform over the exact population.
+- `hoyt/sampled_br.py` now uses the same traversal in two modes.
+  `SampledCFR` alternates all four seats through one shared sparse regret table;
+  `SampledBR` can fork that candidate, reset one seat, and train while the
+  other three policies remain frozen. Both branch every updater action, sample
+  one current-policy opponent action, and retain only the current frontier.
+  Rows are keyed by seat plus a 62-bit information fingerprint in a sorted
+  hard-cap table. `SparsePolicy` artifacts round-trip to `.npz` and expose a
+  uniform-fallback lookup for downstream consumers.
+- Exact small roots gate both pieces. The four-seat H3 candidate returned
+  22.7288 points (SE 0.0641) versus exact CFR 22.7333 and chose the same root
+  action. On H4 seed 555184, the exact uniform-opponent BR traversed 96.6M
+  nodes in 15.2 s; 64,000 sampled traversals trained in 4.03 s and returned
+  10.8560 (SE 0.02275) versus exact 10.7770, inside the registered four-SE
+  smoke band and with the exact root move.
+- On the established Jud-play H5/910000 root (324,324 physical worlds), the
+  shared candidate trained 25,600 traversals in 13.39 s, evaluated in 0.11 s,
+  used 392,928 rows, and peaked at 16,442 frontier states. Four frozen-policy
+  BR forks plus evaluation took 13.02 s. The provisional profile value was
+  25.620 (95% empirical-Bernstein radius 0.427); the simultaneous bounded-
+  payoff candidate-deviation band was [0, 1.084] before optimization
+  shortfall.
+- On the paired H6/910000 root (17,153,136 worlds), 6,400 shared-CFR
+  traversals trained in 5.37 s and evaluated in 0.13 s, using 305,277 rows and
+  a 27,219-state peak frontier. Four BR forks took another 11.81 s. The
+  provisional profile value was 16.360 (95% empirical-Bernstein radius
+  0.573); root moves 7 and 15 were effectively tied. The simultaneous
+  bounded-payoff candidate-deviation band was [0, 1.528] before optimization
+  shortfall.
+
+Those H5/H6 numbers are end-to-end memory/throughput receipts, **not reference
+claims**. The independently evaluated candidate BRs give a valid route to a
+lower exploitability bound, but are not themselves upper bounds on the true
+best response. Until `metalcal.br_shortfall_upper` is fit on an exchangeable
+exact-root calibration population, the H5/H6 upper gap is infinite and both
+verdicts are correctly `unresolved`. H4/H5 calibration cannot silently be
+called an H6 guarantee; that transfer must be demonstrated or exact
+bounded-memory fixed-profile H6 anchors must be added.
+
+Version 2 still indexes sparse update records on the host between Metal
+microbatches, exports the current rather than a theoretically privileged
+average policy, and schedules roots serially. The production sequence is:
+device-side sparse sort/merge; root-fleet batching; independently trained
+candidate BRs at registered budgets; one-sided shortfall calibration; then
+held-out value, gap, convergence, and action-damage coverage. A new root is
+converged only when candidate uncertainty plus the shortfall bound lies below
+the target; otherwise it remains explicitly unresolved.
 
 ## Non-goals
 

--- a/wiki/topics/full-metal-hoyt.md
+++ b/wiki/topics/full-metal-hoyt.md
@@ -1,0 +1,199 @@
+---
+title: Full-metal Hoyt — a certified GPU referee past H4
+kind: topic
+first_seen: 2026-07-21
+last_updated: 2026-07-21
+status: active
+---
+
+[[hoyt]] already expresses late Texas 42 as a static, wave-structured array
+program, and its roots are mutually independent. The full-metal hypothesis
+survives because those are exactly the two shapes an accelerator can consume:
+wide regular work inside a root and a fleet of roots outside it. The CPU
+campaign also removed the ambiguity about what remains. H4 micro-performance
+has a measured exhaustion receipt, exact world/root quotienting collapses
+nothing, and the surviving own-hand class merge removes only about 3% of
+non-forced strategy slots ([[hoyt-perf-primer]],
+[[endgame-equivalence-census]]).
+
+## Problem statement
+
+Can a **device-resident, root-batched Metal implementation of the complete
+Hoyt reference solve** make H5 and then H6 reference production practical on
+the M5 Max while preserving Hoyt's only load-bearing claim: every published
+profile is a reproducible low-exploitability reference whose final gap is
+priced by exact single-seat best response?
+
+"Complete solve" means the full-width tree build, information-set and
+compressed strategy layout, CFR+ reach/value sweeps, regret and average-policy
+updates, intermediate stop tests, final profile, value, gap, and ledger
+verdict. Uploading CPU-built arrays to accelerate one gather or regret kernel
+does not answer the question. The throughput path must keep a ragged fleet of
+roots resident across iterations, with no host round trip at every wave or
+seat update.
+
+The target is not a faster H4 demo. It is a new habitat for the stable referee:
+an H5 reference line first, then evidence about whether H6 belongs to exact
+enumeration, streaming, or an explicitly licensed approximation. The named
+consumers remain reference-backed [[jud]]/`lens:ev` leaves, a distilled student
+whose error is measurable against game-native values, and durable referee
+values for downstream mechanism work. This is the Hoyt continuation of the
+batch-VCT direction parked for the net-bearing [[walt]] path in
+[#74](https://github.com/jasonyandell/mk5-main/issues/74), not a port of Walt's
+neural field evaluator.
+
+## Why this is the structural move
+
+The stacked evidence removes the cheaper escape hatches:
+
+- [PR #78](https://github.com/jasonyandell/mk5-main/pull/78) made the game a
+  net-free SoA wave program and established the frozen H4 reference problem.
+- [PR #81](https://github.com/jasonyandell/mk5-main/pull/81) removed the
+  Python-object/RSS failure and built the cap-ledger fleet.
+- [PR #83](https://github.com/jasonyandell/mk5-main/pull/83) compressed the
+  exactly inert 83% of forced strategy slots, fused the iteration, priced the
+  gap on the resident structure, made the build resident, and carried the full
+  200-root line to 727 certified H4 evals/hour. The subsequent measured levers
+  mostly compressed away at fleet scale ([[perf-log]] 18l–19i).
+- [PR #84](https://github.com/jasonyandell/mk5-main/pull/84) proved exact
+  world/root equivalence collapse is 1.000× by a depth-independent
+  co-occurrence mechanism. Its strongest surviving class-CFR form is an exact
+  but roughly 3% non-forced-slot tidy, not a width reduction.
+
+One more CPU micro-kernel therefore cannot change Hoyt's habitat. Per
+[[hoyt-perf-primer]], CFR costs about 1.5 orders of magnitude per added tile in
+both time and memory; H5 CFR is not yet priced as a population, and H6 is
+already classified as a different build. The unspent parallelism is the
+population itself: solve many independent roots on the 40-core GPU rather than
+running a handful of memory-contending CPU processes.
+
+## The numerical collision is part of the problem
+
+The verified fused lane is fp64-only. Its built-and-deleted fp32 arm drifted
+`2.59e-3` on the anchor gap, outside the registered `1e-3` license, and bought
+no CPU throughput because that kernel was gather-latency-bound
+([[perf-log]] 18l). Metal Shading Language does not support `double`
+([Metal Shading Language Specification, section 2.1](https://developer.apple.com/metal/Metal-Shading-Language-Specification.pdf)).
+
+Full-metal Hoyt therefore includes a numerical-method problem, not merely a
+kernel-port problem. A successful lane must do one of three things and measure
+which one it chose:
+
+1. reproduce the required fp64 behavior with a higher-precision Metal
+   representation or compensated scheme;
+2. use Metal arithmetic to generate a candidate average profile, then make the
+   existing fp64 engine the sparse final certifier and continuation oracle; or
+3. earn a new numerical license from decision damage and final exact-BR gap,
+   not from raw value drift alone.
+
+The third option may change implementation tolerances; it may not change
+Hoyt's published claim. A profile is a reference only after an authoritative
+gap measurement says so.
+
+## Contract that must survive
+
+The Metal lane consumes the same `(root, worlds, weights, payoff43)` object as
+`hoyt.cfr_solve` and emits the same semantic result:
+
+```
+profile + reference value + exact single-seat-BR gap
++ iteration trace + stop/cap verdict + phase timings
+```
+
+The following are acceptance conditions, not stretch goals:
+
+- **Rules and structure:** legal moves, trick winners, counts, terminal points,
+  chance weights, information-set identity, forced-slot elision, and public
+  path identity come from the existing [[play-phase-algebra]]/LUT contract.
+  Structural fixtures must match the CPU wave engine exactly: wave sizes,
+  parent and move arrays, actors, info-set offsets, terminal points, and slot
+  counts.
+- **Reference semantics:** regret-matching+, alternating four-seat updates,
+  linear averaging, payoff signs, tie rules, and the single-seat deviation gap
+  retain the semantics in [[cfr-primer]] and `hoyt/CONTRACTS.md`.
+- **Certification:** the existing fp64 engine remains the authority until a
+  Metal certifier independently cross-matches it. Every accepted row must end
+  with a full four-seat gap at or below the registered target; an intermediate
+  early-exit test is not a certificate.
+- **Reproducibility:** root/world sampling, arithmetic lane, device identity,
+  iteration trace, final verdict, and any CPU repricing are ledgered. Absence
+  is never a result; OOM, precision rejection, and cap expiry are first-class
+  verdicts.
+- **Honesty:** this remains an agent-form, four-seat low-exploitability
+  reference. Metal does not promote it to a team equilibrium and does not add
+  a team-pair deviation guarantee.
+
+## Hard engineering questions
+
+The implementation has to answer these together because each can erase the
+others' speedup:
+
+- **Ragged fleet layout:** roots differ by orders of magnitude and each wave
+  expands irregularly. The GPU needs a packed root/wave descriptor algebra,
+  stable compaction, and tail handling that do not serialize on the largest
+  root.
+- **Build residency:** H4 fleet wall is already build-heavy, and the one wedge
+  reaches 589.6M slots and about 27 GiB solo. H5 cannot begin by materializing
+  several unconstrained replicas. The design must choose and measure full
+  residency, root/action sharding, or a streaming frontier.
+- **Deterministic reductions:** forward reach, backward value, counterfactual
+  value, and regret matching all contain segmented folds. Atomic accumulation
+  is easy; a reproducible, certifiable fold with acceptable occupancy is the
+  actual requirement.
+- **Precision:** fp32 is the native Metal floating-point lane but has not earned
+  Hoyt's license. Precision, accumulation order, and certification cadence are
+  one design surface.
+- **Device boundary:** CPU orchestration may prepare roots and append ledger
+  rows. It may not rebuild, regroup, or re-upload every wave; otherwise launch
+  and synchronization overhead recreate the Python problem one level lower.
+- **Population scheduling:** throughput is H5/H6 evals per wall hour, not one
+  photogenic root. Root bucketing, dynamic admission, memory pressure, and the
+  wedge path must be graded on a full population.
+
+## Falsification ladder
+
+The build should be killed early if its mechanism does not survive these
+gates:
+
+1. **FM0 — size the target.** Freeze a small stratified H5 evalset and measure
+   the current CPU lane's tree/slot/memory anatomy under explicit world caps.
+   This supplies the budget the Metal lane must close; H5 BR timings are not an
+   H5 CFR baseline.
+2. **FM1 — structural Metal walk.** On toys and selected H4 roots, build the
+   full-width integer structure on-device and match every CPU structural array
+   exactly. No CFR arithmetic is licensed before this passes.
+3. **FM2 — one-iteration cross-gate.** Match reach, leaf, counterfactual,
+   regret, average, and strategy arrays on toys and small real roots under the
+   selected precision scheme. Record drift by operation and depth rather than
+   only at the final scalar.
+4. **FM3 — certified H4 replay.** Run the frozen 200-root H4 line through the
+   new lane. Require zero structural discrepancies, zero false converged
+   verdicts under fp64 repricing, a full per-root decision-damage report, and a
+   measured fleet wall/RSS comparison with the 727-evals/hour reference.
+5. **FM4 — horizon proof.** Produce a certified H5 line inside a pre-registered
+   wall and memory budget. If the lane only improves H4 while H5 remains
+   infeasible, the hypothesis has not achieved its purpose.
+6. **FM5 — consumer proof.** Materialize the reference rows in the same stable
+   format needed by the first named downstream consumer. Kernel throughput
+   without a consumable referee artifact is not completion.
+
+Kill the lane if host synchronization remains wave-shaped, if no numerical
+scheme can pass fp64 certification, if ragged packing leaves the GPU mostly
+idle, or if the resident footprint makes H5 no more feasible than the CPU
+lane. Those are mechanism failures, not invitations to weaken the referee.
+
+## Non-goals
+
+- another H4-only CPU micro-optimization;
+- reviving world/root equivalence after the co-occurrence theorem;
+- porting the Walt/Jud neural field path to MPS;
+- declaring fp32 acceptable because a scalar looks close;
+- replacing the exact-given-worlds reference with sampling without a separate,
+  explicit error contract; or
+- changing Hoyt's equilibrium honesty line.
+
+## Links
+
+[[hoyt]] · [[hoyt-perf-primer]] · [[perf]] · [[perf-log]] ·
+[[endgame-equivalence-census]] · [[cfr-primer]] · [[walt-spec]] ·
+[[play-phase-algebra]]

--- a/wiki/topics/full-metal-hoyt.md
+++ b/wiki/topics/full-metal-hoyt.md
@@ -1,199 +1,95 @@
 ---
-title: Full-metal Hoyt — a certified GPU referee past H4
+title: Full-metal Hoyt — the H5/H6 problem
 kind: topic
 first_seen: 2026-07-21
 last_updated: 2026-07-21
 status: active
 ---
 
-[[hoyt]] already expresses late Texas 42 as a static, wave-structured array
-program, and its roots are mutually independent. The full-metal hypothesis
-survives because those are exactly the two shapes an accelerator can consume:
-wide regular work inside a root and a fleet of roots outside it. The CPU
-campaign also removed the ambiguity about what remains. H4 micro-performance
-has a measured exhaustion receipt, exact world/root quotienting collapses
-nothing, and the surviving own-hand class merge removes only about 3% of
-non-forced strategy slots ([[hoyt-perf-primer]],
-[[endgame-equivalence-census]]).
-
 ## Problem statement
 
-Can a **device-resident, root-batched Metal implementation of the complete
-Hoyt reference solve** make H5 and then H6 reference production practical on
-the M5 Max while preserving Hoyt's only load-bearing claim: every published
-profile is a reproducible low-exploitability reference whose final gap is
-priced by exact single-seat best response?
+Build a **fast, full-Metal [[hoyt]]** that makes H5 and H6 reference solving
+practical on the M5 Max.
 
-"Complete solve" means the full-width tree build, information-set and
-compressed strategy layout, CFR+ reach/value sweeps, regret and average-policy
-updates, intermediate stop tests, final profile, value, gap, and ledger
-verdict. Uploading CPU-built arrays to accelerate one gather or regret kernel
-does not answer the question. The throughput path must keep a ragged fleet of
-roots resident across iterations, with no host round trip at every wave or
-seat update.
+Hoyt currently solves H4 well on the CPU, but each added tile multiplies CFR
+time and memory by roughly 1.5 orders of magnitude. The #78 → #81 → #83 → #84
+stack exhausted the credible CPU and exact-compression levers:
 
-The target is not a faster H4 demo. It is a new habitat for the stable referee:
-an H5 reference line first, then evidence about whether H6 belongs to exact
-enumeration, streaming, or an explicitly licensed approximation. The named
-consumers remain reference-backed [[jud]]/`lens:ev` leaves, a distilled student
-whose error is measurable against game-native values, and durable referee
-values for downstream mechanism work. This is the Hoyt continuation of the
-batch-VCT direction parked for the net-bearing [[walt]] path in
-[#74](https://github.com/jasonyandell/mk5-main/issues/74), not a port of Walt's
-neural field evaluator.
+- H4 is measured at 727 reference evals/hour;
+- forced strategy slots are already compressed away;
+- build, iteration, and gap pricing already operate on resident SoA waves;
+- exact world/root equivalence compresses nothing; and
+- the surviving within-hand class merge removes only about 3% of non-forced
+  slots.
 
-## Why this is the structural move
+The remaining opportunity is the unused parallelism across the solve itself:
+move Hoyt's full-width tree construction, CFR sweeps, and reference evaluation
+onto the GPU, keep the work device-resident, and batch the ragged population of
+roots rather than running a few memory-contending CPU processes.
 
-The stacked evidence removes the cheaper escape hatches:
+The goal is **fast H5, then fast H6**. H4 is the calibration set and performance
+baseline, not the destination.
 
-- [PR #78](https://github.com/jasonyandell/mk5-main/pull/78) made the game a
-  net-free SoA wave program and established the frozen H4 reference problem.
-- [PR #81](https://github.com/jasonyandell/mk5-main/pull/81) removed the
-  Python-object/RSS failure and built the cap-ledger fleet.
-- [PR #83](https://github.com/jasonyandell/mk5-main/pull/83) compressed the
-  exactly inert 83% of forced strategy slots, fused the iteration, priced the
-  gap on the resident structure, made the build resident, and carried the full
-  200-root line to 727 certified H4 evals/hour. The subsequent measured levers
-  mostly compressed away at fleet scale ([[perf-log]] 18l–19i).
-- [PR #84](https://github.com/jasonyandell/mk5-main/pull/84) proved exact
-  world/root equivalence collapse is 1.000× by a depth-independent
-  co-occurrence mechanism. Its strongest surviving class-CFR form is an exact
-  but roughly 3% non-forced-slot tidy, not a width reduction.
+## Accuracy requirement
 
-One more CPU micro-kernel therefore cannot change Hoyt's habitat. Per
-[[hoyt-perf-primer]], CFR costs about 1.5 orders of magnitude per added tile in
-both time and memory; H5 CFR is not yet priced as a population, and H6 is
-already classified as a different build. The unspent parallelism is the
-population itself: solve many independent roots on the 40-core GPU rather than
-running a handful of memory-contending CPU processes.
+Bit-for-bit replication of the CPU implementation is a non-goal. Metal may use
+different layouts, reduction orders, and floating-point arithmetic.
 
-## The numerical collision is part of the problem
+The requirement is **confident, measured error bars**. Against CPU-solvable
+reference roots, the Metal lane must establish held-out error distributions for:
 
-The verified fused lane is fp64-only. Its built-and-deleted fp32 arm drifted
-`2.59e-3` on the anchor gap, outside the registered `1e-3` license, and bought
-no CPU throughput because that kernel was gather-latency-bound
-([[perf-log]] 18l). Metal Shading Language does not support `double`
-([Metal Shading Language Specification, section 2.1](https://developer.apple.com/metal/Metal-Shading-Language-Specification.pdf)).
+- reference value;
+- estimated single-seat best-response gap;
+- convergence classification; and
+- action/argmax changes, stratified by decision margin.
 
-Full-metal Hoyt therefore includes a numerical-method problem, not merely a
-kernel-port problem. A successful lane must do one of three things and measure
-which one it chose:
+Those intervals must have pre-registered coverage and must be tight enough to
+support the downstream decision. A result is usable when its reported error bar
+makes the claim honest; it does not need to reproduce the CPU bits. The existing
+fp64 lane is a calibration oracle and audit surface, not a required per-root step
+in the production H5/H6 path.
 
-1. reproduce the required fp64 behavior with a higher-precision Metal
-   representation or compensated scheme;
-2. use Metal arithmetic to generate a candidate average profile, then make the
-   existing fp64 engine the sparse final certifier and continuation oracle; or
-3. earn a new numerical license from decision damage and final exact-BR gap,
-   not from raw value drift alone.
+## What “full Metal” means
 
-The third option may change implementation tolerances; it may not change
-Hoyt's published claim. A profile is a reference only after an authoritative
-gap measurement says so.
+The production path keeps the expensive work on the GPU:
 
-## Contract that must survive
+- full-width wave/tree construction;
+- information-set and strategy layout;
+- CFR forward and backward passes;
+- regret and average-policy updates;
+- gap estimation; and
+- batched scheduling across roots.
 
-The Metal lane consumes the same `(root, worlds, weights, payoff43)` object as
-`hoyt.cfr_solve` and emits the same semantic result:
+Accelerating one kernel while rebuilding or synchronizing every wave on the CPU
+does not solve the problem. The unit of acceleration is the **reference solve
+fleet**, not an isolated loop.
 
-```
-profile + reference value + exact single-seat-BR gap
-+ iteration trace + stop/cap verdict + phase timings
-```
+## Success
 
-The following are acceptance conditions, not stretch goals:
+The work succeeds when it produces:
 
-- **Rules and structure:** legal moves, trick winners, counts, terminal points,
-  chance weights, information-set identity, forced-slot elision, and public
-  path identity come from the existing [[play-phase-algebra]]/LUT contract.
-  Structural fixtures must match the CPU wave engine exactly: wave sizes,
-  parent and move arrays, actors, info-set offsets, terminal points, and slot
-  counts.
-- **Reference semantics:** regret-matching+, alternating four-seat updates,
-  linear averaging, payoff signs, tie rules, and the single-seat deviation gap
-  retain the semantics in [[cfr-primer]] and `hoyt/CONTRACTS.md`.
-- **Certification:** the existing fp64 engine remains the authority until a
-  Metal certifier independently cross-matches it. Every accepted row must end
-  with a full four-seat gap at or below the registered target; an intermediate
-  early-exit test is not a certificate.
-- **Reproducibility:** root/world sampling, arithmetic lane, device identity,
-  iteration trace, final verdict, and any CPU repricing are ledgered. Absence
-  is never a result; OOM, precision rejection, and cap expiry are first-class
-  verdicts.
-- **Honesty:** this remains an agent-form, four-seat low-exploitability
-  reference. Metal does not promote it to a team equilibrium and does not add
-  a team-pair deviation guarantee.
+1. a calibrated Metal lane whose held-out error bars cover the CPU truth;
+2. a measured, practical H5 reference line;
+3. a measured, practical H6 reference line; and
+4. reference artifacts consumable by the player/distillation pipeline.
 
-## Hard engineering questions
-
-The implementation has to answer these together because each can erase the
-others' speedup:
-
-- **Ragged fleet layout:** roots differ by orders of magnitude and each wave
-  expands irregularly. The GPU needs a packed root/wave descriptor algebra,
-  stable compaction, and tail handling that do not serialize on the largest
-  root.
-- **Build residency:** H4 fleet wall is already build-heavy, and the one wedge
-  reaches 589.6M slots and about 27 GiB solo. H5 cannot begin by materializing
-  several unconstrained replicas. The design must choose and measure full
-  residency, root/action sharding, or a streaming frontier.
-- **Deterministic reductions:** forward reach, backward value, counterfactual
-  value, and regret matching all contain segmented folds. Atomic accumulation
-  is easy; a reproducible, certifiable fold with acceptable occupancy is the
-  actual requirement.
-- **Precision:** fp32 is the native Metal floating-point lane but has not earned
-  Hoyt's license. Precision, accumulation order, and certification cadence are
-  one design surface.
-- **Device boundary:** CPU orchestration may prepare roots and append ledger
-  rows. It may not rebuild, regroup, or re-upload every wave; otherwise launch
-  and synchronization overhead recreate the Python problem one level lower.
-- **Population scheduling:** throughput is H5/H6 evals per wall hour, not one
-  photogenic root. Root bucketing, dynamic admission, memory pressure, and the
-  wedge path must be graded on a full population.
-
-## Falsification ladder
-
-The build should be killed early if its mechanism does not survive these
-gates:
-
-1. **FM0 — size the target.** Freeze a small stratified H5 evalset and measure
-   the current CPU lane's tree/slot/memory anatomy under explicit world caps.
-   This supplies the budget the Metal lane must close; H5 BR timings are not an
-   H5 CFR baseline.
-2. **FM1 — structural Metal walk.** On toys and selected H4 roots, build the
-   full-width integer structure on-device and match every CPU structural array
-   exactly. No CFR arithmetic is licensed before this passes.
-3. **FM2 — one-iteration cross-gate.** Match reach, leaf, counterfactual,
-   regret, average, and strategy arrays on toys and small real roots under the
-   selected precision scheme. Record drift by operation and depth rather than
-   only at the final scalar.
-4. **FM3 — certified H4 replay.** Run the frozen 200-root H4 line through the
-   new lane. Require zero structural discrepancies, zero false converged
-   verdicts under fp64 repricing, a full per-root decision-damage report, and a
-   measured fleet wall/RSS comparison with the 727-evals/hour reference.
-5. **FM4 — horizon proof.** Produce a certified H5 line inside a pre-registered
-   wall and memory budget. If the lane only improves H4 while H5 remains
-   infeasible, the hypothesis has not achieved its purpose.
-6. **FM5 — consumer proof.** Materialize the reference rows in the same stable
-   format needed by the first named downstream consumer. Kernel throughput
-   without a consumable referee artifact is not completion.
-
-Kill the lane if host synchronization remains wave-shaped, if no numerical
-scheme can pass fp64 certification, if ragged packing leaves the GPU mostly
-idle, or if the resident footprint makes H5 no more feasible than the CPU
-lane. Those are mechanism failures, not invitations to weaken the referee.
+It fails if the error bars are too wide to support decisions, if host/device
+synchronization dominates, if ragged roots leave the GPU mostly idle, or if the
+result is merely a faster H4 solver.
 
 ## Non-goals
 
-- another H4-only CPU micro-optimization;
-- reviving world/root equivalence after the co-occurrence theorem;
-- porting the Walt/Jud neural field path to MPS;
-- declaring fp32 acceptable because a scalar looks close;
-- replacing the exact-given-worlds reference with sampling without a separate,
-  explicit error contract; or
-- changing Hoyt's equilibrium honesty line.
+- bit replication;
+- identical intermediate arrays or reduction order;
+- per-root CPU certification in production;
+- another H4-only CPU optimization;
+- reviving exact world/root equivalence; or
+- porting Walt's neural field evaluator.
 
-## Links
+## Evidence
 
-[[hoyt]] · [[hoyt-perf-primer]] · [[perf]] · [[perf-log]] ·
-[[endgame-equivalence-census]] · [[cfr-primer]] · [[walt-spec]] ·
-[[play-phase-algebra]]
+[[hoyt-perf-primer]] · [[perf-log]] · [[endgame-equivalence-census]] ·
+[[cfr-primer]] · [PR #78](https://github.com/jasonyandell/mk5-main/pull/78) ·
+[PR #81](https://github.com/jasonyandell/mk5-main/pull/81) ·
+[PR #83](https://github.com/jasonyandell/mk5-main/pull/83) ·
+[PR #84](https://github.com/jasonyandell/mk5-main/pull/84)

--- a/wiki/topics/full-metal-hoyt.md
+++ b/wiki/topics/full-metal-hoyt.md
@@ -2,7 +2,7 @@
 title: Full-metal Hoyt — the H5/H6 problem
 kind: topic
 first_seen: 2026-07-21
-last_updated: 2026-07-21
+last_updated: 2026-07-22
 status: active
 ---
 
@@ -160,6 +160,52 @@ candidate BRs at registered budgets; one-sided shortfall calibration; then
 held-out value, gap, convergence, and action-damage coverage. A new root is
 converged only when candidate uncertainty plus the shortfall bound lies below
 the target; otherwise it remains explicitly unresolved.
+
+## Playable table experiment
+
+`hoyt/play.py` turns the bounded solver into a resumable late-hand player.
+The default table uses [[jud]] only to produce a deterministic two-trick
+prefix, seats the human at the resulting H5 lead, and lets the other three
+seats independently re-solve from their own information sets. The zeb engine
+retains the real deal as referee state; each Hoyt root and its random stream
+depend only on the acting seat's remaining hand plus the public auction and
+play record. A projection gate perturbs the referee's other three hidden hands
+and requires the solver root to remain identical.
+
+The table's default payoff is make/set probability for the live contract
+(`payoff_make`); expected declaring points remains an option. Its displayed
+action bands are simultaneous empirical-Bernstein intervals for evaluation of
+the fixed candidate. They do **not** include optimization shortfall and do not
+upgrade the unresolved reference verdict. Each seat also starts from the
+physical-uniform consistent-world prior: previous actions impose legality and
+void evidence, but are not weighted by a behavior model. This is a real
+imperfect-information player and an intentionally naive belief player.
+
+Two quiet M5 Max end-to-end smokes on seed 910000 established playability, not
+strength:
+
+| entry | remaining plays | forced | Metal re-solves | total solve wall | max one solve |
+|---|---:|---:|---:|---:|---:|
+| H5 | 20 | 12 | 8 | 14.57 s | 4.19 s |
+| H6 | 24 | 13 | 11 | 17.01 s | 3.36 s |
+
+The untouched H5 opening has 324,324 physical worlds. A human-seat hint took
+4.2 s and selected 6-4 over the runner-up by an estimated 1.1 percentage
+points of contract success; the simultaneous evaluation band was ±5.0 points,
+so the table correctly called the choice close. The H5/H6 continuation totals
+above are single warm smokes whose many forced follows make them much cheaper
+than multiplying a root benchmark by every remaining play. They are neither a
+fleet benchmark nor a calibration receipt.
+
+The session is local and resumable:
+
+```bash
+python -u -m hoyt.play --new --interactive --seed 910000 --horizon 5
+```
+
+This consumer answers a question the reference fleet cannot: whether a fuzzy,
+legally information-bounded Hoyt feels coherent at the table. Strength against
+humans or the existing player ladder remains unmeasured.
 
 ## Non-goals
 

--- a/wiki/topics/perf-log.md
+++ b/wiki/topics/perf-log.md
@@ -2,7 +2,7 @@
 title: Perf log — append-only field notes
 kind: topic
 first_seen: 2026-07-18
-last_updated: 2026-07-19
+last_updated: 2026-07-21
 status: active
 ---
 
@@ -1031,3 +1031,52 @@ Code: `plan_shards` → `dispatch_order` + atomic claim files
 measured-exhaustion receipt now includes the scheduling family:
 pools balance to ±1 s, so residual line wall is contention
 inflation + the wedge + barriers — all previously priced.
+
+## 2026-07-21 — full-metal vertical slice: fast rounds survive; dense H6 dies
+
+Custom MLX Metal kernels now execute the forced-slot-compressed CFR+ forward,
+backward, counterfactual, regret, and average updates in float32. This is an
+accuracy-calibrated lane, not a bit-parity lane. Quiet paired measurements:
+H4/555006 iterate 3.506 → 0.282 s (12.4x), full solve 10.31 → 9.63 s;
+H5/910000/eight-world/ten-round iterate 3.150 → 0.327 s (9.6x), but full solve
+25.4 → 34.8 s because construction, audit, and export remain on CPU. H4
+value/gap drift was 0.0336/0.00129 points; H5 was 0.00539/0.00216.
+
+The architecture gate is decisive: H6/910000 at **one world** exceeded
+288,991,264 live slots at play 21 and tripped a 256M cap before iteration.
+The full hidden universe is 17,153,136 worlds. **Dense full-width Metal is
+REFUTED for H6.** The surviving full-metal problem is a bounded-memory
+sampled/streamed structural estimator with calibrated value, gap, convergence,
+and action error bars. The working kernels remain the iterate substrate; no
+further H4 micro-optimization is licensed by this result.
+
+Follow-on in the same implementation session moved average value + exact-
+in-structure single-seat BR pricing to Metal and vectorized the one final
+profile normalization. Re-measured: H4 full solve **10.31 → 3.77 s (2.74x)**,
+iterate 3.506 → 0.225 s (15.6x), BR 1.820 → 0.013 s; H5/eight-world/ten-round
+full solve **25.4 → 19.4 s (1.31x)**, iterate 3.150 → 0.265 s (11.9x).
+
+The bounded replacement now has an end-to-end candidate + auditor receipt.
+Exact DP world sampling runs on Metal without enumerating populations. A
+shared sparse external-sampling CFR learner alternates all four seats; each
+candidate can be frozen, one seat reset, and a separate candidate BR trained
+against the other three. H3 candidate value/root action match exact CFR. The
+uniform-opponent H4/555184 BR smoke trained 64,000 traversals in 4.03 s and
+returned 10.8560 (SE 0.02275) versus exact 10.7770 with the exact root move.
+
+On the registered Jud-play H5/910000 root (324,324 physical worlds), shared
+CFR trained 25,600 traversals in 13.39 s, evaluated in 0.11 s, used 392,928
+rows, and peaked at 16,442 frontier states. Four frozen-policy candidate BR
+forks plus evaluation took 13.02 s. On paired H6/910000 (17,153,136 worlds),
+shared CFR trained 6,400 traversals in 5.37 s and evaluated in 0.13 s, with
+305,277 rows and a 27,219-state peak; four BR forks took 11.81 s.
+
+The H5/H6 simultaneous bounded-payoff empirical-Bernstein candidate-deviation
+bands were [0, 1.084] and [0, 1.528]. Those are finite-sample statistical
+bands for the independently evaluated fixed candidates, not upper bounds on
+the true best responses. No exchangeable
+optimization-shortfall calibration population exists yet, so the true upper
+gaps are infinity and both verdicts are `unresolved`. This is a full-population
+memory/throughput PASS, not a reference verdict. Host sparse indexing,
+root-fleet batching, current-vs-average policy choice, calibrated BR shortfall,
+and held-out action damage remain open.

--- a/wiki/topics/perf.md
+++ b/wiki/topics/perf.md
@@ -147,9 +147,10 @@ issues for perf items per 2026-07-18 directive).
   full reference line is built (`hoyt/reference_h4_v1_cap256.jsonl`,
   200/200 at gap ≤0.05) via the `hoyt/refsweep.py` cascade — law 8's
   shape ([[perf-log]] 18h–19a). The next structural problem is
-  [[full-metal-hoyt]]: a device-resident, root-batched build + CFR +
-  certificate lane aimed at H5/H6, with Metal's lack of fp64 and the
-  already-refuted fp32 license treated as the first correctness gate.
+  [[full-metal-hoyt]]: a fast, device-resident, root-batched build + CFR +
+  evaluation lane aimed directly at practical H5 and H6 reference lines.
+  Acceptance is calibrated error coverage against CPU truth; bit replication
+  and per-root CPU certification are non-goals.
 - **Burl inference**: no confirmed continuous-batching win; production
   picks are turn-aware token budgets + PLE-safe Q4 quant (memory, not
   wall). The sprint is dormant; resume via [[perf-sprint]].

--- a/wiki/topics/perf.md
+++ b/wiki/topics/perf.md
@@ -147,10 +147,15 @@ issues for perf items per 2026-07-18 directive).
   full reference line is built (`hoyt/reference_h4_v1_cap256.jsonl`,
   200/200 at gap ≤0.05) via the `hoyt/refsweep.py` cascade — law 8's
   shape ([[perf-log]] 18h–19a). The next structural problem is
-  [[full-metal-hoyt]]: a fast, device-resident, root-batched build + CFR +
-  evaluation lane aimed directly at practical H5 and H6 reference lines.
-  Acceptance is calibrated error coverage against CPU truth; bit replication
-  and per-root CPU certification are non-goals.
+  [[full-metal-hoyt]]: dense Metal is now measured at 2.74× end-to-end on the
+  H4 anchor and 1.31× on an eight-world H5 specimen, but dense H6 is refuted
+  above 288M slots at one world. The surviving lane now runs shared four-seat
+  sparse CFR plus four frozen-policy BR forks over the full H5/H6 physical
+  populations in about 26/17 seconds on the registered roots. These are
+  bounded-memory receipts, not reference verdicts: the true upper gap remains
+  infinite until BR optimization shortfall is calibrated. Acceptance remains
+  held-out error coverage; bit replication and per-root CPU certification are
+  non-goals.
 - **Burl inference**: no confirmed continuous-batching win; production
   picks are turn-aware token budgets + PLE-safe Q4 quant (memory, not
   wall). The sprint is dormant; resume via [[perf-sprint]].

--- a/wiki/topics/perf.md
+++ b/wiki/topics/perf.md
@@ -2,7 +2,7 @@
 title: Perf — the measured laws of making this project fast
 kind: topic
 first_seen: 2026-07-18
-last_updated: 2026-07-19
+last_updated: 2026-07-21
 status: active
 ---
 
@@ -146,7 +146,10 @@ issues for perf items per 2026-07-18 directive).
   pressure lever is resident footprint ([[perf-log]] 19f). The anchor's
   full reference line is built (`hoyt/reference_h4_v1_cap256.jsonl`,
   200/200 at gap ≤0.05) via the `hoyt/refsweep.py` cascade — law 8's
-  shape ([[perf-log]] 18h–19a).
+  shape ([[perf-log]] 18h–19a). The next structural problem is
+  [[full-metal-hoyt]]: a device-resident, root-batched build + CFR +
+  certificate lane aimed at H5/H6, with Metal's lack of fp64 and the
+  already-refuted fp32 license treated as the first correctness gate.
 - **Burl inference**: no confirmed continuous-batching win; production
   picks are turn-aware token budgets + PLE-safe Q4 quant (memory, not
   wall). The sprint is dormant; resume via [[perf-sprint]].
@@ -157,4 +160,4 @@ issues for perf items per 2026-07-18 directive).
 readers) · [[perf-on-the-table]] · [[walt-spec]] · [[walt]] · [[perf-sprint]] ·
 [[perf-sprint-levers]] · [[perf-sprint-traps]] ·
 [[continuous-batching-dispatcher-design]] · [[batch-throughput-bench]] ·
-[[batched-harvest-resilience]] · [[forge]] · [[jud]]
+[[batched-harvest-resilience]] · [[forge]] · [[jud]] · [[full-metal-hoyt]]


### PR DESCRIPTION
Stacks on #84.

## Outcome

Implements the full-Metal Hoyt vertical slice and finds the architectural break: dense custom-Metal CFR is a real H4/H5 accelerator, but dense H6 is impossible even at one world. The surviving H5/H6 lane is exact world sampling plus bounded sparse external-sampling CFR and independently trained frozen-policy BR candidates.

Bit replication remains an explicit non-goal. The accuracy contract is measured error bars and an honest `unresolved` result whenever the upper gap is not certified.

## Implemented

- custom MLX Metal kernels for dense CFR+ forward/backward, regret/average updates, value, and exact-in-structure gap pricing;
- `engine="metal"` integration in `cfr_solve` and refsweep;
- exact continuation-count DP world sampling, including one sampler per Metal thread;
- shared four-seat sparse sampled CFR over the full physical population;
- frozen-policy per-seat BR forks and bounded-payoff empirical-Bernstein candidate intervals;
- one-sided conformal value/gap/BR-optimization-shortfall primitives;
- versioned sparse candidate-policy artifacts with uniform fallback;
- Metal, world-sampling, sampled-CFR/BR, capacity, artifact, and calibration gates.

## Measured on the M5 Max

- Dense H4: 10.31 -> 3.77 s end to end; iterate 3.506 -> 0.225 s.
- Dense H5, eight worlds / ten rounds: 25.4 -> 19.4 s.
- Dense H6, one world: refuted before iteration at 288,991,264 live slots.
- Full-population H5/910000, 324,324 worlds: shared CFR 13.39 s; four-seat audit 13.02 s.
- Full-population H6/910000, 17,153,136 worlds: shared CFR 5.37 s; four-seat audit 11.81 s; 305,277 sparse rows and 27,219 peak frontier states.

The H5/H6 simultaneous fixed-candidate deviation bands are [0, 1.084] and [0, 1.528]. They do not include BR optimization shortfall. Until that shortfall is calibrated on an exchangeable exact-root population, the true upper gaps are infinity and both convergence verdicts correctly remain `unresolved`.

## Validation

- `python -m pytest -q hoyt/tests` — 38 passed
- Metal gates M1-M3 — green
- world-sampler gates W1-W4 — green, including registered H5/H6 populations
- sampled solver gates S1-S4 — green, including exact H2/H3 checks and frozen-policy artifact/fork checks
- `python scripts/wiki_lint.py --strict` — 535 pages, 0 errors, 0 warnings
- `git diff --check` — clean